### PR TITLE
ci(build): capture integration diagnostics on pytest failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,7 +376,7 @@ jobs:
           token: ${{ env.TRUNK_API_TOKEN }}
 
       - name: Dump Docker diagnostics
-        if: failure()
+        if: ${{ failure() || (steps.integration_pytest.conclusion == 'success' && steps.integration_pytest.outputs.exit_code != '0') }}
         run: |
           docker ps -a
           echo


### PR DESCRIPTION
## Summary
Fix the integration diagnostics step so Docker state is dumped when pytest fails through the captured exit-code path.

## What changed
- run Docker diagnostics when the integration job has a prior hard failure
- also run Docker diagnostics when pytest reports a non-zero exit code through `integration_pytest.outputs.exit_code`
- keep the later explicit fail step as the job gate

## Why
The workflow was swallowing pytest failures until a later step, which meant `if: failure()` was false at the diagnostics step and skipped the exact logs needed for debugging.

## Validation
- trunk check --show-existing --all
- python3 scripts/validate-template.py
- pytest tests/unit tests/template --junit-xml=reports/pytest-unit.xml -o junit_family=xunit1
- pytest tests/integration -m integration --junit-xml=reports/pytest-integration.xml -o junit_family=xunit1
- /tmp/trunk-analytics-cli/trunk-analytics-cli validate --junit-paths "reports/pytest-unit.xml,reports/pytest-integration.xml"
- git diff --check
