### PR TITLE
fix(runtime): validate vector store selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## [v2.0.0-aio.3](https://github.com/JSONbored/mem0-aio/releases/tag/v2.0.0-aio.3) - 2026-04-24
+
 ### CI
+
 - Optimize pytest gating and Trunk uploads by @JSONbored
 - Preserve changelog history and publish release commits by @JSONbored
 - Capture integration diagnostics on pytest failure by @JSONbored
@@ -10,29 +13,28 @@ All notable changes to this project will be documented in this file.
 - Centralize trunk config and gate release tags by @JSONbored
 - Accept squash release titles by @JSONbored
 
-
 ### Dependency Updates
+
 - Update trunk-io/analytics-uploader action to v2 by @renovate[bot]
 - Update dependency pytest to v9 [security] by @renovate[bot]
 
-
 ### Fixes
+
 - Make derived repo validator portable by @JSONbored
 - Use workflow file selector for CI checks by @JSONbored
 - Add authenticated qdrant support by @JSONbored
 
-
 ### Other Changes
+
 - Merge branch 'main' into codex/ci-diagnostics-fixes by @JSONbored
 
-
 ### Tests
+
 - Replace smoke tests with pytest by @JSONbored
 - Unify validation under pytest by @JSONbored
 - Use docker volumes for runtime persistence by @JSONbored
 - Require external backend coverage by @JSONbored
 - Clean container-owned backend storage by @JSONbored
-
 
 ## [v2.0.0-aio.2](https://github.com/JSONbored/mem0-aio/releases/tag/v2.0.0-aio.2) - 2026-04-18
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,7 @@ VOLUME ["/mem0/storage"]
 EXPOSE 3000 8765 6333
 
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=300000
+ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=5 \
   CMD sh -lc 'IP=$(hostname -i | awk "{print \$1}"); curl -fsS "http://${IP}:3000/" >/dev/null || exit 1'

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This repo is deliberately not a stripped-down wrapper. The template now tracks t
 - keep using bundled Qdrant privately by default with telemetry disabled unless you explicitly re-enable it
 - keep the bundled internal defaults for the easiest install while still exposing the upstream env surface for power users
 
+External vector storage is exclusive. Configure one backend only: `REDIS_URL`, `PG_*`, external `QDRANT_*`, Chroma, Weaviate, Milvus, Elasticsearch, OpenSearch, or FAISS. The container rejects competing or partial vector-store selectors instead of letting OpenMemory silently pick the first matching backend.
+
 The wrapper still defaults to the internal bundled storage path so new Unraid users are not forced into extra services on day one.
 
 ## Runtime Notes
@@ -54,6 +56,7 @@ The wrapper still defaults to the internal bundled storage path so new Unraid us
 - The direct API / MCP port is optional for normal browser use because the UI proxies to the API over the same published web port.
 - The embedded Qdrant service is intentionally bundled because that is the critical first-boot dependency for the AIO path. External vector store support remains optional advanced configuration.
 - For authenticated external Qdrant, prefer `QDRANT_URL=http://qdrant:6333` plus `QDRANT_API_KEY` instead of only `QDRANT_HOST` and `QDRANT_PORT`.
+- Do not set `QDRANT_API_KEY` against the bundled Qdrant default. Use `QDRANT_URL` or an external `QDRANT_HOST` when Qdrant auth is enabled.
 - Native Ollama provider support expects the root Ollama URL such as `http://host.docker.internal:11434`, not an OpenAI-compatible `/v1` path.
 - If your homelab front door adds auth and only exposes an OpenAI-style `/v1` endpoint, use the OpenAI-compatible base URL fields instead of the native Ollama provider path.
 - Elasticsearch/OpenSearch support is now wired for real external deployments, but those stacks usually need explicit auth and SSL choices. For Elasticsearch, the advanced template now exposes `ELASTICSEARCH_USE_SSL` and `ELASTICSEARCH_VERIFY_CERTS`. For OpenSearch, it now also exposes optional user/password plus `OPENSEARCH_USE_SSL` and `OPENSEARCH_VERIFY_CERTS`, with SSL defaulting to `true` to match modern secured nodes.

--- a/docs/power-user.md
+++ b/docs/power-user.md
@@ -59,6 +59,8 @@ Notes:
 
 - Default persistent path: `/mem0/storage`
 - This holds the SQLite database and embedded Qdrant data for the AIO deployment
+- The vector-store selector is exclusive. Leave the defaults for bundled Qdrant, or configure exactly one external vector backend.
+- If competing selectors are present, such as `REDIS_URL` plus `PG_HOST` plus external `QDRANT_URL`, the container rejects the configuration instead of guessing.
 
 ## External Overrides
 
@@ -78,6 +80,20 @@ These are optional and only for non-default installs:
 - `ELASTICSEARCH_HOST` / `ELASTICSEARCH_PORT` / `ELASTICSEARCH_USER` / `ELASTICSEARCH_PASSWORD` / `ELASTICSEARCH_USE_SSL` / `ELASTICSEARCH_VERIFY_CERTS`
 - `OPENSEARCH_HOST` / `OPENSEARCH_PORT` / `OPENSEARCH_USER` / `OPENSEARCH_PASSWORD` / `OPENSEARCH_USE_SSL` / `OPENSEARCH_VERIFY_CERTS`
 - `FAISS_PATH`
+
+Selection order inside OpenMemory is Chroma, Weaviate, Redis, PGVector, Milvus, Elasticsearch, OpenSearch, FAISS, then Qdrant. `mem0-aio` now validates the env before startup so that priority order cannot silently hide an accidental second backend.
+
+Minimum external-backend selectors:
+
+- Qdrant: `QDRANT_URL`, or external `QDRANT_HOST` plus `QDRANT_PORT`
+- Redis: `REDIS_URL`
+- PGVector: `PG_HOST` and `PG_PORT`
+- Chroma: `CHROMA_HOST` and `CHROMA_PORT`
+- Weaviate: `WEAVIATE_CLUSTER_URL`, or `WEAVIATE_HOST` and `WEAVIATE_PORT`
+- Milvus: `MILVUS_HOST` and `MILVUS_PORT`
+- Elasticsearch: `ELASTICSEARCH_HOST` and `ELASTICSEARCH_PORT`
+- OpenSearch: `OPENSEARCH_HOST` and `OPENSEARCH_PORT`
+- FAISS: `FAISS_PATH`
 
 ## Export Helper
 
@@ -102,3 +118,5 @@ For authenticated Qdrant, set:
 - `QDRANT_API_KEY` to the Qdrant API key
 
 Do not rely on `QDRANT_HOST` + `QDRANT_PORT` alone for authenticated plain-HTTP Qdrant. The wrapper normalizes this case for compatibility, but `QDRANT_URL` is the explicit and least surprising configuration.
+
+Do not set `QDRANT_API_KEY` against the bundled `127.0.0.1:6333` default. The bundled Qdrant service is not started with API-key auth.

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -21,16 +21,16 @@
 4. Start the container and open the Web UI. The wrapper will auto-default to Ollama when [code]OLLAMA_BASE_URL[/code] is set and no explicit provider overrides are supplied.&#xD;
 5. Only expose the direct API port if you need external MCP/API clients.&#xD;
 &#xD;
-[b]Power Users (Advanced View)[/b]&#xD;
-- Advanced View exposes the practical upstream OpenMemory self-hosted environment surface plus AIO defaults for the bundled SQLite + Qdrant path.&#xD;
-- You can keep the internal defaults, or point OpenMemory at native Ollama, OpenAI-compatible reverse proxies, Anthropic, Groq, Together, DeepSeek, Azure OpenAI, Bedrock-compatible providers, and external vector backends such as pgvector, Weaviate, Redis, Milvus, Elasticsearch, OpenSearch, Chroma, or FAISS.&#xD;
-- Leave defaults in place for the easiest install. Only set the overrides you actually need.&#xD;
+[b]Advanced View[/b]&#xD;
+- Leave storage defaults in place for the bundled SQLite + Qdrant path.&#xD;
+- If you use external vector storage, configure exactly one backend. The wrapper rejects competing selectors such as Redis plus PGVector plus external Qdrant because OpenMemory can only initialize one vector store at a time.&#xD;
+- Provider overrides are available for native Ollama, OpenAI-compatible endpoints, hosted model providers, and supported external vector stores, but only set the fields your chosen path needs.&#xD;
 &#xD;
 [b]Important Notes[/b]&#xD;
 - This wrapper is meant to simplify first boot on Unraid, not remove the real complexity of model/provider credentials and external-service tuning.&#xD;
 - Actual memory generation still requires a valid LLM/embedder configuration. Leaving [code]OPENAI_API_KEY[/code] blank is fine if you are using Ollama, but you still need to provide a reachable Ollama endpoint and valid model names.&#xD;
 - Native Ollama uses the root API URL such as [code]http://host.docker.internal:11434[/code], not an OpenAI-compatible [code]/v1[/code] path. If your reverse proxy adds auth and only exposes an OpenAI-style [code]/v1[/code] endpoint, use the advanced OpenAI-compatible base URL fields instead of the native Ollama provider path.&#xD;
-- The embedded Qdrant service is intentionally bundled because that is the critical dependency for the beginner AIO path.</Overview>
+- The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
   <Changes>### 2026-04-24&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
 - Optimize pytest gating and Trunk uploads by @JSONbored&#xD;
@@ -55,7 +55,7 @@
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/icons/mem0.jpeg</Icon>
   <ExtraSearchTerms>ai memory mcp llm openmemory qdrant ollama anthropic groq deepseek embeddings vector database</ExtraSearchTerms>
-  <Requires>OpenMemory still needs a valid LLM/embedder setup for actual memory generation. For the easiest first boot, keep the bundled storage defaults and then either set OPENAI_API_KEY or point the app at a reachable native Ollama endpoint with chat and embedding models you already have pulled. If you use a nonstandard embedding model and auto-detection is not enough, set EMBEDDER_DIMENSIONS in Advanced View.</Requires>
+  <Requires>OpenMemory still needs a valid LLM/embedder setup for actual memory generation. For the easiest first boot, keep bundled storage defaults and either set OPENAI_API_KEY or point the app at a reachable native Ollama endpoint with chat and embedding models you already have pulled. External vector storage is advanced: configure exactly one backend.</Requires>
   <ExtraParams/>
   <PostArgs/>
   <CPUset/>
@@ -111,22 +111,22 @@
 
   <Config Name="[Storage] DATABASE_URL" Target="DATABASE_URL" Default="sqlite:////mem0/storage/openmemory.db" Mode="" Description="Advanced override for the API database connection. Leave the default SQLite path for normal AIO usage." Type="Variable" Display="advanced" Required="false" Mask="false">sqlite:////mem0/storage/openmemory.db</Config>
   <Config Name="[Legacy] API_KEY Alias" Target="API_KEY" Default="" Mode="" Description="Legacy upstream alias used by older OpenMemory examples that referenced env:API_KEY. Leave blank unless you intentionally depend on that older pattern." Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="[Vector Store:Qdrant] URL" Target="QDRANT_URL" Default="" Mode="" Description="Optional full external Qdrant URL. Use this for authenticated or HTTPS Qdrant endpoints, for example http://qdrant:6333 or https://qdrant.example.com. When set, it takes precedence over QDRANT_HOST and QDRANT_PORT." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:Qdrant] Host" Target="QDRANT_HOST" Default="127.0.0.1" Mode="" Description="Default embedded Qdrant host. Leave unchanged for the bundled AIO path. For authenticated external Qdrant, prefer QDRANT_URL plus QDRANT_API_KEY." Type="Variable" Display="advanced" Required="false" Mask="false">127.0.0.1</Config>
-  <Config Name="[Vector Store:Qdrant] Port" Target="QDRANT_PORT" Default="6333" Mode="" Description="Default embedded Qdrant port. Leave unchanged for the bundled AIO path." Type="Variable" Display="advanced" Required="false" Mask="false">6333</Config>
-  <Config Name="[Vector Store:Qdrant] API Key" Target="QDRANT_API_KEY" Default="" Mode="" Description="Optional API key for authenticated external Qdrant. Masked because it is a secret. For plain HTTP Docker-network Qdrant, set QDRANT_URL to http://qdrant:6333 so the client does not attempt HTTPS." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="[Vector Store:Qdrant] URL" Target="QDRANT_URL" Default="" Mode="" Description="External Qdrant URL, for example http://qdrant:6333 or https://qdrant.example.com. Use this instead of external QDRANT_HOST when auth or HTTPS is involved. Do not combine with Redis, PGVector, or other vector backends." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:Qdrant] Host" Target="QDRANT_HOST" Default="127.0.0.1" Mode="" Description="Bundled Qdrant host by default. Leave as 127.0.0.1 for the AIO path; set to an external host only when Qdrant is the one external vector backend you want." Type="Variable" Display="advanced" Required="false" Mask="false">127.0.0.1</Config>
+  <Config Name="[Vector Store:Qdrant] Port" Target="QDRANT_PORT" Default="6333" Mode="" Description="Qdrant port for the bundled or selected external Qdrant backend." Type="Variable" Display="advanced" Required="false" Mask="false">6333</Config>
+  <Config Name="[Vector Store:Qdrant] API Key" Target="QDRANT_API_KEY" Default="" Mode="" Description="API key for authenticated external Qdrant. Requires QDRANT_URL or an external QDRANT_HOST; the bundled Qdrant service is not started with API-key auth." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="[Vector Store:Qdrant] Disable Telemetry" Target="QDRANT__TELEMETRY_DISABLED" Default="true|false" Mode="" Description="Controls Qdrant usage-statistics reporting for the bundled embedded vector store. Default is true so the AIO image stays privacy-first by default." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
-  <Config Name="[Vector Store:Chroma] Host" Target="CHROMA_HOST" Default="" Mode="" Description="Optional external Chroma host. When set with CHROMA_PORT, OpenMemory will use Chroma instead of Qdrant." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:Chroma] Port" Target="CHROMA_PORT" Default="" Mode="" Description="Optional external Chroma port." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:Weaviate] Cluster URL" Target="WEAVIATE_CLUSTER_URL" Default="" Mode="" Description="Optional full Weaviate cluster URL. If set, it takes precedence over WEAVIATE_HOST and WEAVIATE_PORT." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:Weaviate] Host" Target="WEAVIATE_HOST" Default="" Mode="" Description="Optional external Weaviate host." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:Weaviate] Port" Target="WEAVIATE_PORT" Default="" Mode="" Description="Optional external Weaviate port." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:Redis] URL" Target="REDIS_URL" Default="" Mode="" Description="Optional Redis-backed vector-store URL. Example: redis://:password@host:6379/0" Type="Variable" Display="advanced" Required="false" Mask="true"/>
-  <Config Name="[Vector Store:PGVector] Host" Target="PG_HOST" Default="" Mode="" Description="Optional external PostgreSQL/pgvector host." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:PGVector] Port" Target="PG_PORT" Default="" Mode="" Description="Optional external PostgreSQL/pgvector port." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:PGVector] Database" Target="PG_DB" Default="" Mode="" Description="Optional external PostgreSQL database name for pgvector." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:PGVector] User" Target="PG_USER" Default="" Mode="" Description="Optional external PostgreSQL username for pgvector." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="[Vector Store:PGVector] Password" Target="PG_PASSWORD" Default="" Mode="" Description="Optional external PostgreSQL password for pgvector." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="[Vector Store:Chroma] Host" Target="CHROMA_HOST" Default="" Mode="" Description="External Chroma host. Requires CHROMA_PORT and must be the only external vector backend configured." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:Chroma] Port" Target="CHROMA_PORT" Default="" Mode="" Description="External Chroma port. Requires CHROMA_HOST." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:Weaviate] Cluster URL" Target="WEAVIATE_CLUSTER_URL" Default="" Mode="" Description="External Weaviate cluster URL. Use this or WEAVIATE_HOST/WEAVIATE_PORT, and do not combine with another vector backend." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:Weaviate] Host" Target="WEAVIATE_HOST" Default="" Mode="" Description="External Weaviate host. Requires WEAVIATE_PORT unless WEAVIATE_CLUSTER_URL is set." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:Weaviate] Port" Target="WEAVIATE_PORT" Default="" Mode="" Description="External Weaviate port. Requires WEAVIATE_HOST unless WEAVIATE_CLUSTER_URL is set." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:Redis] URL" Target="REDIS_URL" Default="" Mode="" Description="Redis-backed vector-store URL. Example: redis://:password@host:6379/0. This selects Redis as the vector backend; do not combine with PGVector or Qdrant." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="[Vector Store:PGVector] Host" Target="PG_HOST" Default="" Mode="" Description="External PostgreSQL/pgvector host. Requires PG_PORT and must be the only external vector backend configured." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:PGVector] Port" Target="PG_PORT" Default="" Mode="" Description="External PostgreSQL/pgvector port. Required when any PG_* vector-store setting is used." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:PGVector] Database" Target="PG_DB" Default="" Mode="" Description="External PostgreSQL database name for pgvector. Defaults to mem0 when PGVector is selected and this is blank." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:PGVector] User" Target="PG_USER" Default="" Mode="" Description="External PostgreSQL username for pgvector. Defaults to mem0 when PGVector is selected and this is blank." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="[Vector Store:PGVector] Password" Target="PG_PASSWORD" Default="" Mode="" Description="External PostgreSQL password for pgvector. Defaults to mem0 when PGVector is selected and this is blank." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="[Vector Store:Milvus] Host" Target="MILVUS_HOST" Default="" Mode="" Description="Optional external Milvus host." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="[Vector Store:Milvus] Port" Target="MILVUS_PORT" Default="" Mode="" Description="Optional external Milvus port." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="[Vector Store:Milvus] Token" Target="MILVUS_TOKEN" Default="" Mode="" Description="Optional Milvus token for authenticated deployments." Type="Variable" Display="advanced" Required="false" Mask="true"/>

--- a/rootfs/etc/cont-init.d/01-bootstrap.sh
+++ b/rootfs/etc/cont-init.d/01-bootstrap.sh
@@ -2,6 +2,9 @@
 # shellcheck shell=bash
 set -euo pipefail
 
+# shellcheck source=/dev/null
+source /etc/mem0-aio/env-helpers.sh
+
 mkdir -p /mem0/storage
 
 export USER="${USER:-default_user}"
@@ -12,6 +15,8 @@ export QDRANT_HOST="${QDRANT_HOST:-127.0.0.1}"
 export QDRANT_PORT="${QDRANT_PORT:-6333}"
 export QDRANT__TELEMETRY_DISABLED="${QDRANT__TELEMETRY_DISABLED:-true}"
 export OPENAI_API_KEY="${OPENAI_API_KEY-}"
+
+mem0_validate_vector_store_config
 
 : >/var/run/mem0-aio.env
 

--- a/rootfs/etc/mem0-aio/env-helpers.sh
+++ b/rootfs/etc/mem0-aio/env-helpers.sh
@@ -1,25 +1,112 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 
-mem0_uses_external_vector_store() {
-	if [[ -n ${CHROMA_HOST-} ]] || [[ -n ${WEAVIATE_CLUSTER_URL-} ]] ||
-		[[ -n ${WEAVIATE_HOST-} ]] || [[ -n ${REDIS_URL-} ]] ||
-		[[ -n ${PG_HOST-} ]] || [[ -n ${MILVUS_HOST-} ]] ||
-		[[ -n ${ELASTICSEARCH_HOST-} ]] || [[ -n ${OPENSEARCH_HOST-} ]] ||
-		[[ -n ${FAISS_PATH-} ]]; then
-		return 0
-	fi
-
-	if [[ -n ${QDRANT_URL-} ]]; then
-		return 0
-	fi
-
-	case "${QDRANT_HOST:-127.0.0.1}" in
+_mem0_is_local_qdrant_host() {
+	case "${1:-127.0.0.1}" in
 	127.0.0.1 | localhost | "")
-		return 1
+		return 0
 		;;
 	*)
-		return 0
+		return 1
 		;;
 	esac
+}
+
+_mem0_vector_store_candidates() {
+	local candidates=()
+
+	if [[ -n ${CHROMA_HOST-} ]] || [[ -n ${CHROMA_PORT-} ]]; then
+		candidates+=(chroma)
+	fi
+	if [[ -n ${WEAVIATE_CLUSTER_URL-} ]] || [[ -n ${WEAVIATE_HOST-} ]] || [[ -n ${WEAVIATE_PORT-} ]]; then
+		candidates+=(weaviate)
+	fi
+	if [[ -n ${REDIS_URL-} ]]; then
+		candidates+=(redis)
+	fi
+	if [[ -n ${PG_HOST-} ]] || [[ -n ${PG_PORT-} ]] || [[ -n ${PG_DB-} ]] || [[ -n ${PG_USER-} ]] || [[ -n ${PG_PASSWORD-} ]]; then
+		candidates+=(pgvector)
+	fi
+	if [[ -n ${MILVUS_HOST-} ]] || [[ -n ${MILVUS_PORT-} ]] || [[ -n ${MILVUS_TOKEN-} ]] || [[ -n ${MILVUS_DB_NAME-} ]]; then
+		candidates+=(milvus)
+	fi
+	if [[ -n ${ELASTICSEARCH_HOST-} ]] || [[ -n ${ELASTICSEARCH_PORT-} ]] || [[ -n ${ELASTICSEARCH_USER-} ]] || [[ -n ${ELASTICSEARCH_PASSWORD-} ]]; then
+		candidates+=(elasticsearch)
+	fi
+	if [[ -n ${OPENSEARCH_HOST-} ]] || [[ -n ${OPENSEARCH_PORT-} ]] || [[ -n ${OPENSEARCH_USER-} ]] || [[ -n ${OPENSEARCH_PASSWORD-} ]]; then
+		candidates+=(opensearch)
+	fi
+	if [[ -n ${FAISS_PATH-} ]]; then
+		candidates+=(faiss)
+	fi
+	if [[ -n ${QDRANT_URL-} ]] || [[ -n ${QDRANT_API_KEY-} ]] || ! _mem0_is_local_qdrant_host "${QDRANT_HOST:-127.0.0.1}"; then
+		candidates+=(qdrant)
+	fi
+
+	printf '%s\n' "${candidates[@]}"
+}
+
+mem0_validate_vector_store_config() {
+	local candidates=()
+	local candidate
+	# shellcheck disable=SC2312
+	while IFS= read -r candidate; do
+		[[ -n ${candidate} ]] && candidates+=("${candidate}")
+	done < <(_mem0_vector_store_candidates)
+
+	if ((${#candidates[@]} > 1)); then
+		printf 'mem0-aio configuration error: choose exactly one vector store backend; found %s.\n' "${candidates[*]}" >&2
+		printf 'Set only one of QDRANT_*, REDIS_URL, PG_*, CHROMA_*, WEAVIATE_*, MILVUS_*, ELASTICSEARCH_*, OPENSEARCH_*, or FAISS_PATH.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${CHROMA_HOST-} || -n ${CHROMA_PORT-} ]] && [[ -z ${CHROMA_HOST-} || -z ${CHROMA_PORT-} ]]; then
+		printf 'mem0-aio configuration error: Chroma requires both CHROMA_HOST and CHROMA_PORT.\n' >&2
+		return 1
+	fi
+
+	if [[ -z ${WEAVIATE_CLUSTER_URL-} ]] && [[ -n ${WEAVIATE_HOST-} || -n ${WEAVIATE_PORT-} ]] && [[ -z ${WEAVIATE_HOST-} || -z ${WEAVIATE_PORT-} ]]; then
+		printf 'mem0-aio configuration error: Weaviate requires WEAVIATE_CLUSTER_URL or both WEAVIATE_HOST and WEAVIATE_PORT.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${PG_HOST-} || -n ${PG_PORT-} || -n ${PG_DB-} || -n ${PG_USER-} || -n ${PG_PASSWORD-} ]] && [[ -z ${PG_HOST-} || -z ${PG_PORT-} ]]; then
+		printf 'mem0-aio configuration error: PGVector requires at least PG_HOST and PG_PORT when any PG_* override is set.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${MILVUS_HOST-} || -n ${MILVUS_PORT-} || -n ${MILVUS_TOKEN-} || -n ${MILVUS_DB_NAME-} ]] && [[ -z ${MILVUS_HOST-} || -z ${MILVUS_PORT-} ]]; then
+		printf 'mem0-aio configuration error: Milvus requires at least MILVUS_HOST and MILVUS_PORT when any MILVUS_* override is set.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${ELASTICSEARCH_HOST-} || -n ${ELASTICSEARCH_PORT-} || -n ${ELASTICSEARCH_USER-} || -n ${ELASTICSEARCH_PASSWORD-} ]] && [[ -z ${ELASTICSEARCH_HOST-} || -z ${ELASTICSEARCH_PORT-} ]]; then
+		printf 'mem0-aio configuration error: Elasticsearch requires at least ELASTICSEARCH_HOST and ELASTICSEARCH_PORT when any Elasticsearch host or credential override is set.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${OPENSEARCH_HOST-} || -n ${OPENSEARCH_PORT-} || -n ${OPENSEARCH_USER-} || -n ${OPENSEARCH_PASSWORD-} ]] && [[ -z ${OPENSEARCH_HOST-} || -z ${OPENSEARCH_PORT-} ]]; then
+		printf 'mem0-aio configuration error: OpenSearch requires at least OPENSEARCH_HOST and OPENSEARCH_PORT when any OpenSearch host or credential override is set.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${QDRANT_API_KEY-} && -z ${QDRANT_URL-} ]] && _mem0_is_local_qdrant_host "${QDRANT_HOST:-127.0.0.1}"; then
+		printf 'mem0-aio configuration error: QDRANT_API_KEY requires QDRANT_URL or an external QDRANT_HOST. The bundled Qdrant service is not started with API-key auth.\n' >&2
+		return 1
+	fi
+
+	if [[ -n ${QDRANT_URL-} ]] && ! _mem0_is_local_qdrant_host "${QDRANT_HOST:-127.0.0.1}"; then
+		printf 'mem0-aio configuration error: set QDRANT_URL or external QDRANT_HOST/QDRANT_PORT, not both.\n' >&2
+		return 1
+	fi
+}
+
+mem0_uses_external_vector_store() {
+	local candidates=()
+	local candidate
+	# shellcheck disable=SC2312
+	while IFS= read -r candidate; do
+		[[ -n ${candidate} ]] && candidates+=("${candidate}")
+	done < <(_mem0_vector_store_candidates)
+	((${#candidates[@]} > 0))
 }

--- a/rootfs/etc/services.d/qdrant/run
+++ b/rootfs/etc/services.d/qdrant/run
@@ -3,6 +3,8 @@ set -euo pipefail
 
 source /etc/mem0-aio/env-helpers.sh
 
+mem0_validate_vector_store_config
+
 if mem0_uses_external_vector_store; then
     echo "External vector store configured; skipping bundled Qdrant startup."
     exec sleep infinity

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -123,3 +123,34 @@ def test_happy_path_boot_and_restart(built_image: str) -> None:
             assert container_path_exists(
                 name, "/mem0/storage/openmemory.db"
             )  # nosec B101
+
+
+def test_competing_vector_store_config_exits(built_image: str) -> None:
+    name = f"mem0-aio-invalid-vector-{uuid.uuid4().hex[:10]}"
+    result = run_command(
+        [
+            "docker",
+            "run",
+            "--name",
+            name,
+            "--platform",
+            "linux/amd64",
+            "-e",
+            "REDIS_URL=redis://redis:6379/0",
+            "-e",
+            "PG_HOST=postgres",
+            "-e",
+            "PG_PORT=5432",
+            "-e",
+            "QDRANT_URL=http://qdrant:6333",
+            built_image,
+        ],
+        check=False,
+    )
+    try:
+        output = result.stdout + result.stderr
+        assert result.returncode == 1  # nosec B101
+        assert "choose exactly one vector store backend" in output  # nosec B101
+        assert "redis pgvector qdrant" in output  # nosec B101
+    finally:
+        run_command(["docker", "rm", "-f", name], check=False)

--- a/tests/template/test_container_contract.py
+++ b/tests/template/test_container_contract.py
@@ -77,6 +77,7 @@ def test_unraid_metadata_contract_is_complete_and_unprivileged() -> None:
         "Project",
         "TemplateURL",
         "Icon",
+        "Category",
         "WebUI",
     ):
         value = root.findtext(tag)
@@ -153,6 +154,7 @@ def test_dockerfile_has_runtime_safety_contract() -> None:
     assert "curl -fsS" in dockerfile  # nosec B101
     assert 'ENTRYPOINT ["/init"]' in dockerfile  # nosec B101
     assert "S6_CMD_WAIT_FOR_SERVICES_MAXTIME" in dockerfile  # nosec B101
+    assert "S6_BEHAVIOUR_IF_STAGE2_FAILS=2" in dockerfile  # nosec B101
 
 
 def test_docker_socket_mount_is_advanced_and_documented_when_present() -> None:

--- a/tests/template/test_env_helpers.py
+++ b/tests/template/test_env_helpers.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import subprocess  # nosec B404 - tests execute trusted local helper scripts
+
+from tests.conftest import REPO_ROOT
+
+ENV_HELPERS = REPO_ROOT / "rootfs/etc/mem0-aio/env-helpers.sh"
+
+
+def run_vector_helper(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    command = (
+        f"source {ENV_HELPERS}; "
+        "mem0_validate_vector_store_config && "
+        "if mem0_uses_external_vector_store; then echo external; else echo bundled; fi"
+    )
+    return subprocess.run(  # nosec B603 - trusted local bash validation helper
+        ["/bin/bash", "-lc", command],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_default_qdrant_uses_bundled_vector_store() -> None:
+    result = run_vector_helper({"QDRANT_HOST": "127.0.0.1", "QDRANT_PORT": "6333"})
+
+    assert result.returncode == 0  # nosec B101
+    assert result.stdout.strip() == "bundled"  # nosec B101
+
+
+def test_redis_pgvector_and_external_qdrant_are_rejected_together() -> None:
+    result = run_vector_helper(
+        {
+            "REDIS_URL": "redis://redis:6379/0",
+            "PG_HOST": "postgres",
+            "PG_PORT": "5432",
+            "QDRANT_URL": "http://qdrant:6333",
+        }
+    )
+
+    assert result.returncode == 1  # nosec B101
+    assert "choose exactly one vector store backend" in result.stderr  # nosec B101
+    assert "redis pgvector qdrant" in result.stderr  # nosec B101
+
+
+def test_pgvector_partial_config_is_rejected() -> None:
+    result = run_vector_helper({"PG_HOST": "postgres"})
+
+    assert result.returncode == 1  # nosec B101
+    assert (
+        "PGVector requires at least PG_HOST and PG_PORT" in result.stderr
+    )  # nosec B101
+
+
+def test_qdrant_api_key_requires_external_endpoint() -> None:
+    result = run_vector_helper(
+        {
+            "QDRANT_HOST": "127.0.0.1",
+            "QDRANT_PORT": "6333",
+            "QDRANT_API_KEY": "secret",
+        }
+    )
+
+    assert result.returncode == 1  # nosec B101
+    assert (
+        "QDRANT_API_KEY requires QDRANT_URL or an external QDRANT_HOST" in result.stderr
+    )  # nosec B101
+
+
+def test_external_qdrant_host_disables_bundled_store() -> None:
+    result = run_vector_helper({"QDRANT_HOST": "qdrant", "QDRANT_PORT": "6333"})
+
+    assert result.returncode == 0  # nosec B101
+    assert result.stdout.strip() == "external"  # nosec B101


### PR DESCRIPTION
## Summary
- reject ambiguous external vector-store env combinations before OpenMemory starts
- document the real one-backend selection model in the Unraid template and docs
- add focused coverage for bundled Qdrant, external Qdrant, partial PGVector, and competing backend selectors

## What changed
- validates QDRANT_*, REDIS_URL, PG_*, Chroma, Weaviate, Milvus, Elasticsearch, OpenSearch, and FAISS selectors in the wrapper
- sets s6 to fail fast when cont-init validation fails
- tightens Advanced View help text in the source XML
- extends the shared container contract to require s6 fail-fast behavior

## Why
- OpenMemory can only initialize one vector store, and the previous env priority could silently hide impossible combinations such as Redis plus PGVector plus external Qdrant

## Validation
- `.venv-local/bin/pytest tests/unit tests/template`
- `.venv-local/bin/python scripts/validate-template.py`
- `.venv-local/bin/pytest tests/integration/test_container_runtime.py`
- manual invalid-container probe with REDIS_URL + PG_* + QDRANT_URL returned exit status 1
- `trunk check` on touched files
- `git diff --check`

## Notes
- `awesome-unraid` is intentionally untouched; catalog templates are synced from source AIO repos.