### PR TITLE
ci(fleet): sync workflow path filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,20 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/**"
       - ".github/workflows/**"
       - ".trunk/**"
+      - "AGENTS.md"
       - "CHANGELOG.md"
       - "Dockerfile"
+      - "README.md"
+      - "SECURITY.md"
+      - "SUPPORT.md"
       - "assets/**"
       - "cliff.toml"
       - "components.toml"
       - "components/**"
+      - "docs/**"
       - "docs/upstream/**"
       - "mem0-aio.xml"
       - "openmemory"
@@ -26,14 +32,20 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/**"
       - ".github/workflows/**"
       - ".trunk/**"
+      - "AGENTS.md"
       - "CHANGELOG.md"
       - "Dockerfile"
+      - "README.md"
+      - "SECURITY.md"
+      - "SUPPORT.md"
       - "assets/**"
       - "cliff.toml"
       - "components.toml"
       - "components/**"
+      - "docs/**"
       - "docs/upstream/**"
       - "mem0-aio.xml"
       - "openmemory"
@@ -56,7 +68,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@337b82e04d6d1b887c704326a967bb1b10416752
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@01163d070460034ea975df7b57d34b6178f33e97
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@337b82e04d6d1b887c704326a967bb1b10416752
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@01163d070460034ea975df7b57d34b6178f33e97
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@337b82e04d6d1b887c704326a967bb1b10416752
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@01163d070460034ea975df7b57d34b6178f33e97
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@337b82e04d6d1b887c704326a967bb1b10416752
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@01163d070460034ea975df7b57d34b6178f33e97
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Updates this repository's thin AIO workflow callers to the latest aio-fleet reusable workflow pin.

## What changed
- Bumps the aio-fleet reusable workflow ref.
- Includes the expanded path filters for shared boilerplate and support metadata changes.

## Why
- Ensures boilerplate-only PRs trigger the required aio-build checks instead of requiring manual workflow dispatches.

## Validation
- Generated from JSONbored/aio-fleet manifest after aio-fleet#10.

## Notes
- Local SSH commit signing is blocked in this session because the Strongbox agent exposes no signing identities; this branch commit was created unsigned, and the PR should be squash-merged through GitHub.