### PR TITLE
refactor(fleet): use shared derived repo validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@388300f0f98701ea81bd8185660257d06cd8f472
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@388300f0f98701ea81bd8185660257d06cd8f472
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@388300f0f98701ea81bd8185660257d06cd8f472
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@388300f0f98701ea81bd8185660257d06cd8f472
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7
     permissions:
       contents: write
       pull-requests: write

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -2,96 +2,37 @@
 set -euo pipefail
 
 repo_root="${1:-.}"
-cd "${repo_root}"
 strict_placeholders="${STRICT_PLACEHOLDERS:-false}"
 
-fail() {
-	echo "template validation error: $*" >&2
-	exit 1
-}
-
-require_file() {
-	local path="$1"
-	[[ -f ${path} ]] || fail "missing required file: ${path}"
-}
-
-require_absent() {
-	local path="$1"
-	[[ ! -e ${path} ]] || fail "remove template placeholder path in derived repo: ${path}"
-}
-
-check_no_placeholder() {
-	local pattern="$1"
-	shift
-	if grep -F -n -- "${pattern}" "$@" >/dev/null 2>&1; then
-		fail "found unresolved placeholder '${pattern}' in: $*"
-	fi
-}
-
-require_file "Dockerfile"
-require_file "README.md"
-require_file "pyproject.toml"
-require_file "tests/template/test_validate_template.py"
-require_file "tests/integration/test_container_runtime.py"
-require_file "scripts/validate-template.py"
-require_file "scripts/update-template-changes.py"
-require_file ".github/FUNDING.yml"
-require_file "SECURITY.md"
-require_file ".github/pull_request_template.md"
-require_file ".github/ISSUE_TEMPLATE/bug_report.yml"
-require_file ".github/ISSUE_TEMPLATE/feature_request.yml"
-require_file ".github/ISSUE_TEMPLATE/installation_help.yml"
-require_file ".github/ISSUE_TEMPLATE/config.yml"
-require_file "renovate.json"
-require_absent ".github/CODEOWNERS"
-
-effective_template_xml="${TEMPLATE_XML-}"
-if [[ -z ${effective_template_xml} ]]; then
-	repo_name="${PWD##*/}"
-	inferred_repo_xml="${repo_name}.xml"
-	if [[ -f ${inferred_repo_xml} ]]; then
-		effective_template_xml="${inferred_repo_xml}"
-	else
-		root_xml_files=()
-		shopt -s nullglob
-		for xml_path in ./*.xml; do
-			[[ -f ${xml_path} ]] || continue
-			root_xml_files+=("${xml_path#./}")
-		done
-		shopt -u nullglob
-		if [[ ${#root_xml_files[@]} -eq 1 ]]; then
-			effective_template_xml="${root_xml_files[0]}"
-		fi
-	fi
-fi
-
-is_template_repo="false"
-if [[ -f .github/workflows/publish-release.yml ]] && grep -F -q -- "Publish Release / Template" .github/workflows/publish-release.yml; then
-	is_template_repo="true"
-fi
-
-if [[ -n ${effective_template_xml} ]]; then
-	require_file "${effective_template_xml}"
-	if [[ ${is_template_repo} != "true" ]]; then
-		require_absent "template-aio.xml"
-	fi
-fi
-
-xml_files=()
-if [[ -n ${effective_template_xml} ]] && [[ -f ${effective_template_xml} ]]; then
-	xml_files+=("${effective_template_xml}")
-fi
-
+args=(validate-derived --repo-path "${repo_root}")
 if [[ ${strict_placeholders} == "true" ]]; then
-	check_no_placeholder "Replace this starter base with the real upstream image once the derived repo is wired." "Dockerfile"
-	if [[ ${#xml_files[@]} -gt 0 ]]; then
-		check_no_placeholder "yourapp-aio" "${xml_files[@]}"
-		check_no_placeholder "Replace this overview with the real app description and first-run guidance." "${xml_files[@]}"
-		check_no_placeholder "replace-with-real-search-terms" "${xml_files[@]}"
-		check_no_placeholder "Replace this with any real operational prerequisites or remove it." "${xml_files[@]}"
-		check_no_placeholder "https://github.com/JSONbored/yourapp-aio/releases" "${xml_files[@]}"
-	fi
-	check_no_placeholder "aio-template starter app" rootfs/etc/services.d/app/run rootfs/usr/local/bin/aio-template-app.py
+	args+=(--strict-placeholders)
 fi
 
-echo "Derived repo validation passed."
+if python3 -c "import aio_fleet" >/dev/null 2>&1; then
+	exec python3 -m aio_fleet.cli "${args[@]}"
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+candidate_roots=()
+if [[ -n ${AIO_FLEET_PATH-} ]]; then
+	candidate_roots+=("${AIO_FLEET_PATH}")
+fi
+candidate_roots+=(
+	"${script_dir}/../../aio-fleet"
+	"${script_dir}/../../../aio-fleet"
+	"../aio-fleet"
+	"../../aio-fleet"
+)
+
+for candidate in "${candidate_roots[@]}"; do
+	if [[ -d ${candidate}/src/aio_fleet ]]; then
+		PYTHONPATH="${candidate}/src${PYTHONPATH:+:${PYTHONPATH}}" exec python3 -m aio_fleet.cli "${args[@]}"
+	fi
+done
+
+cat >&2 <<'EOF'
+template validation error: aio-fleet is required for derived repo validation.
+Install aio-fleet or set AIO_FLEET_PATH to a local aio-fleet checkout.
+EOF
+exit 1


### PR DESCRIPTION
## Summary
- Replaces the copied derived-repo validation logic with the shared `aio-fleet` shim
- Bumps reusable AIO workflow callers to `aio-fleet@6cb527a4cccd624ad73447b6b73cda9b56b4c9c7`

## What changed
- `scripts/validate-derived-repo.sh` now delegates to `aio-fleet validate-derived`
- Generated workflow callers now reference the fleet SHA that contains the centralized validator

## Why
- Keeps derived-repo validation behavior centralized in `aio-fleet`
- Reduces duplicated validator logic across the active AIO fleet while preserving the existing script entrypoint

## Validation
- `python3 scripts/validate-template.py --all`
- `bash scripts/validate-derived-repo.sh .`
- `git diff --check`
- `actionlint -shellcheck '' -pyflakes '' -ignore 'SC2129' .github/workflows/*.yml`
- `python -m aio_fleet verify-caller --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio --ref 6cb527a4cccd624ad73447b6b73cda9b56b4c9c7`
