### PR TITLE
fix(fleet): sync release shim path fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@c2c7c9a58496ce5c65e8952dc57fe455f8547833
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@c2c7c9a58496ce5c65e8952dc57fe455f8547833
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@c2c7c9a58496ce5c65e8952dc57fe455f8547833
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@c2c7c9a58496ce5c65e8952dc57fe455f8547833
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@294c30f6f88dcabf2ef7467f0def0ad4e3b18b74
     permissions:
       contents: write
       pull-requests: write

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 
 def _add_local_aio_fleet() -> None:
     repo_root = Path(__file__).resolve().parents[1]
+    configured_path = os.environ.get("AIO_FLEET_PATH")
     for candidate in (
+        Path(configured_path).expanduser() / "src" if configured_path else None,
         repo_root / ".aio-fleet" / "src",
         repo_root.parent / "aio-fleet" / "src",
     ):
-        if candidate.exists():
+        if candidate and candidate.exists():
             sys.path.insert(0, str(candidate))
             return
 
@@ -23,8 +26,9 @@ def main() -> int:
     except ModuleNotFoundError as exc:
         raise SystemExit(
             "aio_fleet.release is required. Run from the standard workspace with "
-            "../aio-fleet present, or let the reusable aio-fleet workflows check "
-            "out .aio-fleet before invoking this shim."
+            "../aio-fleet present, set AIO_FLEET_PATH to a local aio-fleet checkout, "
+            "or let the reusable aio-fleet workflows check out .aio-fleet before "
+            "invoking this shim."
         ) from exc
 
     return int(


### PR DESCRIPTION
## Summary
- Syncs the managed release shim from `aio-fleet` so `AIO_FLEET_PATH` works in non-adjacent worktrees.
- Repins the thin workflow callers to the current merged `aio-fleet` control-plane SHA.

## What changed
- Updated `scripts/release.py` from fleet boilerplate.
- Updated reusable workflow pins to `294c30f6f88dcabf2ef7467f0def0ad4e3b18b74`.

## Why
- The release shim worked in normal sibling checkouts and CI, but failed for isolated worktrees unless `aio-fleet` was adjacent.

## Validation
- `aio-fleet sync-workflows --dry-run`
- `aio-fleet sync-boilerplate --dry-run`
- `aio-fleet validate --all`
- repo-local `pytest tests/unit tests/template`
- `git diff --check`