### PR TITLE
test(template): run shared metadata validation

### DIFF
--- a/scripts/validate-template.py
+++ b/scripts/validate-template.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import re
+import subprocess  # nosec B404
 import sys
 import xml.etree.ElementTree as ET  # nosec B405
 from pathlib import Path
@@ -81,6 +83,62 @@ LEGACY_CHANGELOG_MARKERS = (
 )
 
 
+def run_common_template_validation() -> int:
+    candidates = []
+    explicit = os.environ.get("AIO_FLEET_MANIFEST", "").strip()
+    if explicit:
+        candidates.append(Path(explicit))
+    candidates.extend(
+        [
+            ROOT / ".aio-fleet" / "fleet.yml",
+            ROOT.parent / "aio-fleet" / "fleet.yml",
+        ]
+    )
+    manifest = next((candidate for candidate in candidates if candidate.exists()), None)
+    if manifest is None:
+        print(
+            "warning: aio-fleet manifest not found; skipping common template validation",
+            file=sys.stderr,
+        )
+        return 0
+
+    env = os.environ.copy()
+    fleet_src = manifest.parent / "src"
+    if fleet_src.exists():
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            f"{fleet_src}{os.pathsep}{existing}" if existing else str(fleet_src)
+        )
+    python = sys.executable
+    fleet_python = manifest.parent / ".venv" / "bin" / "python"
+    if fleet_python.exists():
+        python = str(fleet_python)
+
+    result = subprocess.run(  # nosec B603
+        [
+            python,
+            "-m",
+            "aio_fleet.cli",
+            "--manifest",
+            str(manifest),
+            "validate-template-common",
+            "--repo",
+            ROOT.name,
+            "--repo-path",
+            str(ROOT),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")
+    return result.returncode
+
+
 def validate_changes(changes: str) -> str | None:
     for marker in LEGACY_CHANGELOG_MARKERS:
         if marker in changes:
@@ -100,6 +158,10 @@ def validate_changes(changes: str) -> str | None:
 
 
 def main() -> int:
+    common_status = run_common_template_validation()
+    if common_status:
+        return common_status
+
     tree = ET.parse(TEMPLATE_PATH)  # nosec B314
     root = tree.getroot()
 


### PR DESCRIPTION
## Summary
- run shared aio-fleet template metadata validation before Mem0-specific target checks
- keep Mem0 runtime and vector-provider checks local

## Validation
- .venv/bin/python scripts/validate-template.py
- .venv/bin/python -m pytest tests/template