### PR TITLE
ci(publish): pin Docker Hub primary workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       contents: write
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The wrapper still defaults to the internal bundled storage path so new Unraid us
 - Release notes are generated with `git-cliff`.
 - The Unraid template `<Changes>` block is synced from `CHANGELOG.md` during release preparation.
 - `main` publishes `latest`, the pinned upstream version tag, an explicit AIO packaging line tag, and `sha-<commit>`.
-- When Docker Hub credentials are configured, the same publish flow pushes Docker Hub tags in parallel with GHCR so the CA template can read Docker Hub metadata.
+- Publish jobs require Docker Hub credentials and push the CA-facing Docker Hub tags directly.
 
 See [docs/releases.md](docs/releases.md) for the release workflow details.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,7 +18,7 @@ Every `main` build publishes:
 
 Release commits also publish the exact immutable release package tag, for example `v2.0.0-aio.1`. Ordinary `main` pushes do not overwrite that release tag.
 
-When Docker Hub credentials are configured, the same tag set is pushed to Docker Hub in parallel with GHCR.
+Publish jobs require Docker Hub credentials and push the same tag set to Docker Hub directly.
 
 ## Release flow
 


### PR DESCRIPTION
## Summary
- repin caller workflows to the Docker Hub-primary aio-fleet reusable workflow
- update release docs to remove stale GHCR mirror wording

## Validation
- scripts/validate-template.py
- pytest tests/template