### PR TITLE
build(docker): harden apt package installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://|https://|g' {} + && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
+    apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates="$(apt-cache madison ca-certificates | awk 'NR==1 {print $3}')" \
     curl="$(apt-cache madison curl | awk 'NR==1 {print $3}')" \
     xz-utils="$(apt-cache madison xz-utils | awk 'NR==1 {print $3}')" \


### PR DESCRIPTION
## Summary
- Add apt retry and timeout configuration before package installs.
- Rewrite inherited apt sources from http to https before update/install.

## Why
- Package mirror stalls caused publish-time Docker builds to fail or hang in central fleet checks.

## Validation
- aio-fleet validate --all
- aio-fleet cleanup-repo --all --verify
- aio-fleet trunk run --repo mem0-aio --repo-path ../mem0-aio --no-fix
- git diff --check