### PR TITLE
fix(docker): preserve inherited apt source scheme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://|https://|g' {} + && \
-    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
     apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates="$(apt-cache madison ca-certificates | awk 'NR==1 {print $3}')" \
     curl="$(apt-cache madison curl | awk 'NR==1 {print $3}')" \


### PR DESCRIPTION
## Summary
- keep apt retry/timeout hardening for the mem0 image
- stop rewriting Ubuntu base apt sources from HTTP to HTTPS before ca-certificates exists

## Why
The previous hardening pass made mem0 builds fail during apt bootstrap because the Ubuntu 26.04 base image had no CA certificates available yet, so HTTPS apt indexes could not be verified. Preserving the base image source scheme avoids that bootstrapping failure while retaining retry/timeout behavior.

## Validation
- `git diff --check`
- `python -m aio_fleet validate-template-common --repo mem0-aio --repo-path ../mem0-aio`
- `python -m aio_fleet trunk run --repo mem0-aio --repo-path ../mem0-aio --no-fix`

## Notes
- A narrow local apt probe progressed past the certificate failure but was stopped because Ubuntu resolute mirrors remained very slow from the local environment. The central publish path should still prove the full image build before this becomes the published image.