### PR TITLE
chore(release): v2.0.1-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,175 +2,191 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v2.0.0-aio.3](https://github.com/JSONbored/mem0-aio/releases/tag/v2.0.0-aio.3) - 2026-04-25
+## v2.0.1-aio.1 - 2026-05-05
+
+### Build
+
+- Harden apt package installs
 
 ### CI
 
-- Optimize pytest gating and Trunk uploads by @JSONbored
-- Preserve changelog history and publish release commits by @JSONbored
-- Capture integration diagnostics on pytest failure by @JSONbored
-- Remove automation flag and align publish flow by @JSONbored
-- Centralize trunk config and gate release tags by @JSONbored
-- Accept squash release titles by @JSONbored
-- Target the release commit on merged PRs by @JSONbored
-- Fetch history for release tag lookup by @JSONbored
-- Consolidate pytest workflow steps by @JSONbored
-
-### Dependency Updates
-
-- Update trunk-io/analytics-uploader action to v2 by @renovate[bot]
-- Update dependency pytest to v9 [security] by @renovate[bot]
-- Update ubuntu docker tag to v26 by @renovate[bot]
-
-### Documentation
-
-- Format changelog by @JSONbored
-
-### Fixes
-
-- Make derived repo validator portable by @JSONbored
-- Use workflow file selector for CI checks by @JSONbored
-- Add authenticated qdrant support by @JSONbored
-- Classify local action changes by @JSONbored
-
-### Other Changes
-
-- Merge branch 'main' into codex/ci-diagnostics-fixes by @JSONbored
-- Merge branch 'main' into codex/release-target-immutability by @JSONbored
-- Harden vector store selection and Unraid template guidance by @JSONbored
-
-### Tests
-
-- Replace smoke tests with pytest by @JSONbored
-- Unify validation under pytest by @JSONbored
-- Use docker volumes for runtime persistence by @JSONbored
-- Require external backend coverage by @JSONbored
-- Clean container-owned backend storage by @JSONbored
-- Cover action and container contracts by @JSONbored
-- Require init fail-fast contract by @JSONbored
-- Cover invalid vector store config by @JSONbored
-
-## [v2.0.0-aio.3](https://github.com/JSONbored/mem0-aio/releases/tag/v2.0.0-aio.3) - 2026-04-24
-
-### CI
-
-- Optimize pytest gating and Trunk uploads by @JSONbored
-- Preserve changelog history and publish release commits by @JSONbored
-- Capture integration diagnostics on pytest failure by @JSONbored
-- Remove automation flag and align publish flow by @JSONbored
-- Centralize trunk config and gate release tags by @JSONbored
-- Accept squash release titles by @JSONbored
-
-### Dependency Updates
-
-- Update trunk-io/analytics-uploader action to v2 by @renovate[bot]
-- Update dependency pytest to v9 [security] by @renovate[bot]
-
-### Fixes
-
-- Make derived repo validator portable by @JSONbored
-- Use workflow file selector for CI checks by @JSONbored
-- Add authenticated qdrant support by @JSONbored
-
-### Other Changes
-
-- Merge branch 'main' into codex/ci-diagnostics-fixes by @JSONbored
-
-### Tests
-
-- Replace smoke tests with pytest by @JSONbored
-- Unify validation under pytest by @JSONbored
-- Use docker volumes for runtime persistence by @JSONbored
-- Require external backend coverage by @JSONbored
-- Clean container-owned backend storage by @JSONbored
-
-## [v2.0.0-aio.2](https://github.com/JSONbored/mem0-aio/releases/tag/v2.0.0-aio.2) - 2026-04-18
-
-### Fixes
-
-- Align healthcheck and template auto defaults by @JSONbored
-- Align provider auto mode and container healthcheck by @JSONbored
-- Point openmemory submodule to maintained fork by @JSONbored
-
-### Other Changes
-
-- Document Ollama and external backend setup by @JSONbored
-
-## [v2.0.0-aio.1](https://github.com/JSONbored/mem0-aio/releases/tag/v2.0.0-aio.1) - 2026-04-17
+- Use shared AIO build workflow
+- Centralize release workflows
+- Repin shared workflow ref
+- Centralize workflow drift checks
+- Repin caller workflows
+- Pin catalog asset manifest
+- Pin shared validation policy
+- Use shared AIO workflows
+- Sync workflow path filters
+- Sync catalog publication state
+- Pin publish helper workflow fix
+- Pin next-wave aio-fleet workflows
+- Pin Docker Hub primary workflow
+- Pin control-plane workflow foundation
 
 ### Documentation
 
-- Update Socialify banner by @JSONbored
+- Document central app test dependencies
 
 ### Features
 
-- Align mem0-aio with OpenMemory v2.0.0 by @JSONbored
+- Expose manual publish targets
 
 ### Fixes
 
-- Make releases manual and gate heavy workflows by @JSONbored
-- Harden publish and changelog range by @JSONbored
-
-## [v1.0.9-aio.1](https://github.com/JSONbored/mem0-aio/releases/tag/v1.0.9-aio.1) - 2026-04-17
-
-### Dependency Updates
-
-- Update non-major infrastructure updates by @renovate[bot]
-- Update node.js to v24 by @renovate[bot]
-- Pin ubuntu docker tag to 186072b by @renovate[bot]
-- Update docker/build-push-action action to v7 by @renovate[bot]
-- Update docker/setup-buildx-action action to v4 by @renovate[bot]
-- Update docker/setup-qemu-action action to v4 by @renovate[bot]
-- Update docker/metadata-action action to v6 by @renovate[bot]
-- Update docker/login-action action to v4 by @renovate[bot]
-
-### Documentation
-
-- Add repository guidance by @JSONbored
-
-### Features
-
-- Initial commit for Mem0 AIO Unraid template with s6-overlay by @JSONbored
-- Complete AIO docker build for mem0 openmemory with all s6 hooks and awesome-unraid xml by @JSONbored
-- Add git-cliff release workflow by @JSONbored
-
-### Fixes
-
-- Tighten changelog spacing by @JSONbored
-- Make releases manual and gate heavy workflows by @JSONbored
-- Harden publish and changelog range by @JSONbored
+- Align mem0 icon sync target
+- Sync shared validation and trunk cleanup
+- Sync release shim path fallback
+- Preserve inherited apt source scheme
 
 ### Maintenance
 
-- Standardize README, add FUNDING.yml, and clean up legacy files by @JSONbored
-- Prepare for clean submodule by @JSONbored
-- Standardize template by @JSONbored
-- Add template sync workflow by @JSONbored
-- Revert to verifiable bot identity for non-repudiation by @JSONbored
+- Sync shared repository boilerplate
+- Move shared automation to aio-fleet
+- Declare aio-fleet ownership
+- Bump mem0 to v2.0.1
+
+### Refactors
+
+- Use shared derived repo validation
+- Use shared release helper shim
+- Remove legacy shared contract tests
+
+### Tests
+
+- Repin workflow expectation
+- Run shared metadata validation
+
+## v2.0.0-aio.3 - 2026-04-25
+
+### CI
+
+- Optimize pytest gating and Trunk uploads
+- Preserve changelog history and publish release commits
+- Capture integration diagnostics on pytest failure
+- Remove automation flag and align publish flow
+- Centralize trunk config and gate release tags
+- Accept squash release titles
+- Target the release commit on merged PRs
+- Fetch history for release tag lookup
+- Consolidate pytest workflow steps
+
+### Dependency Updates
+
+- Update trunk-io/analytics-uploader action to v2
+- Update dependency pytest to v9 [security]
+- Update ubuntu docker tag to v26
+
+### Documentation
+
+- Format changelog
+
+### Fixes
+
+- Make derived repo validator portable
+- Use workflow file selector for CI checks
+- Add authenticated qdrant support
+- Classify local action changes
 
 ### Other Changes
 
-- Force rebuild to publish docker image by @JSONbored
-- Security & CI: Fix node24 deprecation and package write permissions by @JSONbored
-- Link Mem0 as recursive submodule and update CI to include submodules in build by @JSONbored
-- Adjust Dockerfile COPY paths to match actual OpenMemory submodule structure by @JSONbored
-- Harden mem0-aio and add smoke testing by @JSONbored
-- Harden mem0-aio workflows and upstream tracking by @JSONbored
-- Add Codex repo memory notes by @JSONbored
-- Add renovate.json by @renovate[bot]
-- Merge branch 'main' into codex/harden-mem0-aio by @JSONbored
-- Reduce smoke-test CI usage by @JSONbored
-- Standardize funding and security docs by @JSONbored
-- Add standard community templates by @JSONbored
-- Consolidate CI workflows by @JSONbored
-- Consolidate CI workflows by @JSONbored
-- Merge main into consolidate-ci-workflows by @JSONbored
-- Merge remote-tracking branch 'origin/main' into codex/reduce-smoke-ci by @JSONbored
-- Fix awesome-unraid sync for protected main by @JSONbored
-- Standardize upstream-aligned image tags by @JSONbored
+- Merge branch 'main' into codex/ci-diagnostics-fixes
+- Merge branch 'main' into codex/release-target-immutability
+- Harden vector store selection and Unraid template guidance
 
-### New Contributors
+### Tests
 
-- @JSONbored made their first contribution in [#21](https://github.com/JSONbored/mem0-aio/pull/21)
-- @renovate[bot] made their first contribution
+- Replace smoke tests with pytest
+- Unify validation under pytest
+- Use docker volumes for runtime persistence
+- Require external backend coverage
+- Clean container-owned backend storage
+- Cover action and container contracts
+- Require init fail-fast contract
+- Cover invalid vector store config
+
+## v2.0.0-aio.2 - 2026-04-18
+
+### Fixes
+
+- Align healthcheck and template auto defaults
+- Align provider auto mode and container healthcheck
+- Point openmemory submodule to maintained fork
+
+### Other Changes
+
+- Document Ollama and external backend setup
+
+## v2.0.0-aio.1 - 2026-04-17
+
+### Documentation
+
+- Update Socialify banner
+
+### Features
+
+- Align mem0-aio with OpenMemory v2.0.0
+
+### Fixes
+
+- Make releases manual and gate heavy workflows
+- Harden publish and changelog range
+
+## v1.0.9-aio.1 - 2026-03-31
+
+### Dependency Updates
+
+- Update non-major infrastructure updates
+- Update node.js to v24
+- Pin ubuntu docker tag to 186072b
+- Update docker/build-push-action action to v7
+- Update docker/setup-buildx-action action to v4
+- Update docker/setup-qemu-action action to v4
+- Update docker/metadata-action action to v6
+- Update docker/login-action action to v4
+
+### Documentation
+
+- Add repository guidance
+
+### Features
+
+- Initial commit for Mem0 AIO Unraid template with s6-overlay
+- Complete AIO docker build for mem0 openmemory with all s6 hooks and awesome-unraid xml
+- Add git-cliff release workflow
+
+### Fixes
+
+- Tighten changelog spacing
+
+### Maintenance
+
+- Standardize README, add FUNDING.yml, and clean up legacy files
+- Prepare for clean submodule
+- Standardize template
+- Add template sync workflow
+- Revert to verifiable bot identity for non-repudiation
+
+### Other Changes
+
+- Force rebuild to publish docker image
+- Security & CI: Fix node24 deprecation and package write permissions
+- Link Mem0 as recursive submodule and update CI to include submodules in build
+- Adjust Dockerfile COPY paths to match actual OpenMemory submodule structure
+- Harden mem0-aio and add smoke testing
+- Harden mem0-aio workflows and upstream tracking
+- Add Codex repo memory notes
+- Add renovate.json
+- Merge branch 'main' into codex/harden-mem0-aio
+- Reduce smoke-test CI usage
+- Standardize funding and security docs
+- Add standard community templates
+- Consolidate CI workflows
+- Consolidate CI workflows
+- Merge main into consolidate-ci-workflows
+- Merge remote-tracking branch 'origin/main' into codex/reduce-smoke-ci
+- Fix awesome-unraid sync for protected main
+- Standardize upstream-aligned image tags
+
 <!-- generated by git-cliff -->

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -31,36 +31,38 @@
 - Actual memory generation still requires a valid LLM/embedder configuration. Leaving [code]OPENAI_API_KEY[/code] blank is fine if you are using Ollama, but you still need to provide a reachable Ollama endpoint and valid model names.&#xD;
 - Native Ollama uses the root API URL such as [code]http://host.docker.internal:11434[/code], not an OpenAI-compatible [code]/v1[/code] path. If your reverse proxy adds auth and only exposes an OpenAI-style [code]/v1[/code] endpoint, use the advanced OpenAI-compatible base URL fields instead of the native Ollama provider path.&#xD;
 - The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
-  <Changes>### 2026-04-25&#xD;
+  <Changes>### 2026-05-05&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Optimize pytest gating and Trunk uploads by @JSONbored&#xD;
-- Preserve changelog history and publish release commits by @JSONbored&#xD;
-- Capture integration diagnostics on pytest failure by @JSONbored&#xD;
-- Remove automation flag and align publish flow by @JSONbored&#xD;
-- Centralize trunk config and gate release tags by @JSONbored&#xD;
-- Accept squash release titles by @JSONbored&#xD;
-- Target the release commit on merged PRs by @JSONbored&#xD;
-- Fetch history for release tag lookup by @JSONbored&#xD;
-- Consolidate pytest workflow steps by @JSONbored&#xD;
-- Update trunk-io/analytics-uploader action to v2 by @renovate[bot]&#xD;
-- Update dependency pytest to v9 [security] by @renovate[bot]&#xD;
-- Update ubuntu docker tag to v26 by @renovate[bot]&#xD;
-- Format changelog by @JSONbored&#xD;
-- Make derived repo validator portable by @JSONbored&#xD;
-- Use workflow file selector for CI checks by @JSONbored&#xD;
-- Add authenticated qdrant support by @JSONbored&#xD;
-- Classify local action changes by @JSONbored&#xD;
-- Merge branch 'main' into codex/ci-diagnostics-fixes by @JSONbored&#xD;
-- Merge branch 'main' into codex/release-target-immutability by @JSONbored&#xD;
-- Harden vector store selection and Unraid template guidance by @JSONbored&#xD;
-- Replace smoke tests with pytest by @JSONbored&#xD;
-- Unify validation under pytest by @JSONbored&#xD;
-- Use docker volumes for runtime persistence by @JSONbored&#xD;
-- Require external backend coverage by @JSONbored&#xD;
-- Clean container-owned backend storage by @JSONbored&#xD;
-- Cover action and container contracts by @JSONbored&#xD;
-- Require init fail-fast contract by @JSONbored&#xD;
-- Cover invalid vector store config by @JSONbored</Changes>
+- Harden apt package installs&#xD;
+- Use shared AIO build workflow&#xD;
+- Centralize release workflows&#xD;
+- Repin shared workflow ref&#xD;
+- Centralize workflow drift checks&#xD;
+- Repin caller workflows&#xD;
+- Pin catalog asset manifest&#xD;
+- Pin shared validation policy&#xD;
+- Use shared AIO workflows&#xD;
+- Sync workflow path filters&#xD;
+- Sync catalog publication state&#xD;
+- Pin publish helper workflow fix&#xD;
+- Pin next-wave aio-fleet workflows&#xD;
+- Pin Docker Hub primary workflow&#xD;
+- Pin control-plane workflow foundation&#xD;
+- Document central app test dependencies&#xD;
+- Expose manual publish targets&#xD;
+- Align mem0 icon sync target&#xD;
+- Sync shared validation and trunk cleanup&#xD;
+- Sync release shim path fallback&#xD;
+- Preserve inherited apt source scheme&#xD;
+- Sync shared repository boilerplate&#xD;
+- Move shared automation to aio-fleet&#xD;
+- Declare aio-fleet ownership&#xD;
+- Bump mem0 to v2.0.1&#xD;
+- Use shared derived repo validation&#xD;
+- Use shared release helper shim&#xD;
+- Remove legacy shared contract tests&#xD;
+- Repin workflow expectation&#xD;
+- Run shared metadata validation</Changes>
   <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare v2.0.1-aio.1 release metadata

## What changed
- update CHANGELOG.md and mem0-aio.xml
- refresh release notes and Unraid template Changes metadata from central aio-fleet release tooling

## Why
- formalize the current main branch state as a release so changelog, GitHub Release, Docker Hub, GHCR, and catalog metadata stay aligned

## Validation
- python -m aio_fleet validate --repo mem0-aio
- python -m aio_fleet validate-template-common --repo mem0-aio
- git diff --check
- python -m aio_fleet control-check --repo mem0-aio --sha aa69e78836cee4426e6baba3f43edd546d799a9f --event pull_request --dry-run --no-integration

## Notes
- source repo only; catalog sync follows validated source changes if needed
- release commit signature verified locally with git verify-commit HEAD
