### PR TITLE
fix(security): tighten mem0 runtime defaults

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -31,7 +31,6 @@ upstream:
       release_notes_url: https://github.com/mem0ai/mem0/releases
       submodule_path: openmemory
       submodule_remote: origin
-      submodule_ref_template: codex/openmemory-{version}-aio
 template:
   xml_paths:
     - mem0-aio.xml
@@ -77,6 +76,7 @@ validation:
     - LLM_BASE_URL
     - LLM_MODEL
     - LLM_PROVIDER
+    - MEM0_API_HOST
     - MILVUS_DB_NAME
     - MILVUS_HOST
     - MILVUS_PORT

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openmemory"]
 	path = openmemory
-	url = https://github.com/JSONbored/mem0
+	url = https://github.com/mem0ai/mem0

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ FROM ubuntu:26.04@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97be
 ARG S6_OVERLAY_VERSION=3.2.0.0
 ARG TARGETARCH
 
+COPY --from=qdrant-bin /etc/ssl/certs /etc/ssl/certs
+COPY --from=qdrant-bin /etc/ca-certificates.conf /etc/ca-certificates.conf
+COPY --from=qdrant-bin /usr/share/ca-certificates /usr/share/ca-certificates
+
 # Install system dependencies, python, nodejs
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_NO_CACHE_DIR=1
@@ -33,7 +37,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt";\n' > /etc/apt/apt.conf.d/80-retries && \
+    find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://|https://|g' {} + && \
     apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates="$(apt-cache madison ca-certificates | awk 'NR==1 {print $3}')" \
     curl="$(apt-cache madison curl | awk 'NR==1 {print $3}')" \
@@ -118,14 +123,15 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_API_URL=/openmemory-api
 ENV NEXT_PUBLIC_USER_ID=default_user
 ENV USER=default_user
+ENV MEM0_API_HOST=127.0.0.1
 ENV HOST="0.0.0.0"
 ENV PORT="3000"
 
 # Volumes
 VOLUME ["/mem0/storage"]
 
-# Expose ports: UI (3000), MCP API (8765), Qdrant (6333)
-EXPOSE 3000 8765 6333
+# Expose ports: UI (3000), Qdrant (6333). The MCP/API service binds to localhost by default.
+EXPOSE 3000 6333
 
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=300000
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Unraid-first, single-container deployment of [Mem0 OpenMemory](https://github
 ## What This Image Includes
 
 - OpenMemory web UI on port `3000`
-- OpenMemory API / MCP server on port `8765`
+- OpenMemory API / MCP server on internal localhost port `8765`
 - Embedded Qdrant vector store
 - Persistent appdata storage for SQLite and Qdrant state
 - Upstream backup/export helper scripts bundled into the image
@@ -53,13 +53,13 @@ The wrapper still defaults to the internal bundled storage path so new Unraid us
 ## Runtime Notes
 
 - As of `2026-04-17`, upstream Mem0 has a newer stable release than the original wrapper baseline; this repo is being moved to the current stable `v2.0.0` line rather than staying on the older `v1.0.x` line.
-- The direct API / MCP port is optional for normal browser use because the UI proxies to the API over the same published web port.
+- The direct API / MCP port is optional for normal browser use because the UI proxies to the API over the same published web port. By default, the API binds to `127.0.0.1` inside the container and is not published by the Unraid template; set `MEM0_API_HOST=0.0.0.0` only when intentionally publishing port `8765` behind your own network or reverse-proxy access controls.
 - The embedded Qdrant service is intentionally bundled because that is the critical first-boot dependency for the AIO path. External vector store support remains optional advanced configuration.
 - For authenticated external Qdrant, prefer `QDRANT_URL=http://qdrant:6333` plus `QDRANT_API_KEY` instead of only `QDRANT_HOST` and `QDRANT_PORT`.
 - Do not set `QDRANT_API_KEY` against the bundled Qdrant default. Use `QDRANT_URL` or an external `QDRANT_HOST` when Qdrant auth is enabled.
 - Native Ollama provider support expects the root Ollama URL such as `http://host.docker.internal:11434`, not an OpenAI-compatible `/v1` path.
 - If your homelab front door adds auth and only exposes an OpenAI-style `/v1` endpoint, use the OpenAI-compatible base URL fields instead of the native Ollama provider path.
-- Elasticsearch/OpenSearch support is now wired for real external deployments, but those stacks usually need explicit auth and SSL choices. For Elasticsearch, the advanced template now exposes `ELASTICSEARCH_USE_SSL` and `ELASTICSEARCH_VERIFY_CERTS`. For OpenSearch, it now also exposes optional user/password plus `OPENSEARCH_USE_SSL` and `OPENSEARCH_VERIFY_CERTS`, with SSL defaulting to `true` to match modern secured nodes.
+- Elasticsearch/OpenSearch support is now wired for real external deployments, but those stacks usually need explicit auth and SSL choices. For Elasticsearch, the advanced template exposes `ELASTICSEARCH_USE_SSL` and `ELASTICSEARCH_VERIFY_CERTS`. For OpenSearch, it exposes optional user/password plus `OPENSEARCH_USE_SSL` and `OPENSEARCH_VERIFY_CERTS`. SSL and certificate verification both default to `true`; set verification to `false` only for a trusted self-signed endpoint on a private network.
 - If you expose OpenMemory beyond your LAN, treat the direct MCP/API surface and your model/provider credentials as real attack surface.
 
 ## Publishing and Releases

--- a/docs/power-user.md
+++ b/docs/power-user.md
@@ -6,7 +6,7 @@
 
 - The Web UI is the primary published port.
 - The UI talks to the API through `/openmemory-api` by default.
-- Publish `8765` only if you want direct API or MCP access from external clients.
+- Publish `8765` only if you want direct API or MCP access from external clients. The API binds to `127.0.0.1` by default; set `MEM0_API_HOST=0.0.0.0` only when deliberately exposing that port behind your own access controls.
 
 ## Provider Configuration
 
@@ -30,6 +30,7 @@ Useful variables:
 - `EMBEDDER_API_KEY`
 - `EMBEDDER_BASE_URL`
 - `EMBEDDER_DIMENSIONS`
+- `MEM0_API_HOST`
 - `NEXT_PUBLIC_API_URL`
 - `NEXT_PUBLIC_USER_ID`
 
@@ -94,6 +95,8 @@ Minimum external-backend selectors:
 - Elasticsearch: `ELASTICSEARCH_HOST` and `ELASTICSEARCH_PORT`
 - OpenSearch: `OPENSEARCH_HOST` and `OPENSEARCH_PORT`
 - FAISS: `FAISS_PATH`
+
+Keep `ELASTICSEARCH_VERIFY_CERTS=true` and `OPENSEARCH_VERIFY_CERTS=true` for external HTTPS backends. Set either value to `false` only for a trusted self-signed endpoint on a private network.
 
 ## Export Helper
 

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -19,7 +19,7 @@
 2. For the fastest hosted path, set [code]OPENAI_API_KEY[/code].&#xD;
 3. For the normal local-LLM homelab path, set [code]OLLAMA_BASE_URL[/code] to your external Ollama root URL and set the Ollama chat/embed models you actually have pulled.&#xD;
 4. Start the container and open the Web UI. The wrapper will auto-default to Ollama when [code]OLLAMA_BASE_URL[/code] is set and no explicit provider overrides are supplied.&#xD;
-5. Only expose the direct API port if you need external MCP/API clients.&#xD;
+5. Leave the direct API/MCP port unpublished unless you intentionally need external MCP/API clients behind your own access controls.&#xD;
 &#xD;
 [b]Advanced View[/b]&#xD;
 - Leave storage defaults in place for the bundled SQLite + Qdrant path.&#xD;
@@ -84,11 +84,6 @@
         <ContainerPort>3000</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
-      <Port>
-        <HostPort>8765</HostPort>
-        <ContainerPort>8765</ContainerPort>
-        <Protocol>tcp</Protocol>
-      </Port>
     </Publish>
   </Networking>
   <Data>
@@ -100,7 +95,7 @@
   </Data>
 
   <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Main OpenMemory web interface port." Type="Port" Display="always" Required="true" Mask="false">3000</Config>
-  <Config Name="API / MCP Port" Target="8765" Default="8765" Mode="tcp" Description="Direct API and MCP port. The UI works without exposing this externally, but external MCP clients may need it." Type="Port" Display="advanced" Required="false" Mask="false">8765</Config>
+  <Config Name="API / MCP Port" Target="8765" Default="" Mode="tcp" Description="Optional direct API and MCP host port. Leave blank for normal UI-only access. If you publish this port, also set [Security] API Bind Address to 0.0.0.0 and protect access at your network or reverse proxy." Type="Port" Display="advanced" Required="false" Mask="false"></Config>
   <Config Name="AppData - OpenMemory Storage" Target="/mem0/storage" Default="/mnt/user/appdata/mem0-aio/storage" Mode="rw" Description="Persistent storage for the SQLite database, embedded Qdrant data, and AIO state." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/mem0-aio/storage</Config>
 
   <Config Name="OpenAI API Key" Target="OPENAI_API_KEY" Default="" Mode="" Description="Optional hosted-provider quick start. Leave blank if you plan to use Ollama instead." Type="Variable" Display="always" Required="false" Mask="true"/>
@@ -109,6 +104,7 @@
   <Config Name="Ollama Chat Model" Target="LLM_MODEL" Default="" Mode="" Description="Optional Ollama chat model override. Set this to a model you already have pulled on your Ollama server. Example: llama3.1:latest or mistral:7b" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Ollama Embed Model" Target="EMBEDDER_MODEL" Default="" Mode="" Description="Optional Ollama embedding model override. Set this to a model you already have pulled on your Ollama server. Example: nomic-embed-text" Type="Variable" Display="always" Required="false" Mask="false"/>
 
+  <Config Name="[Security] API Bind Address" Target="MEM0_API_HOST" Default="127.0.0.1" Mode="" Description="Bind address for the internal API/MCP server. Keep 127.0.0.1 for UI-only access; use 0.0.0.0 only when deliberately publishing the API port behind your own access controls." Type="Variable" Display="advanced" Required="false" Mask="false">127.0.0.1</Config>
   <Config Name="[UI] Browser API URL" Target="NEXT_PUBLIC_API_URL" Default="/openmemory-api" Mode="" Description="Default same-origin proxy path for the web UI. Leave this alone unless you intentionally want the browser to call a different API URL directly." Type="Variable" Display="advanced" Required="false" Mask="false">/openmemory-api</Config>
   <Config Name="[UI] Public User ID" Target="NEXT_PUBLIC_USER_ID" Default="default_user" Mode="" Description="Default user ID shown in the browser client. Usually keep this aligned with USER." Type="Variable" Display="advanced" Required="false" Mask="false">default_user</Config>
 
@@ -149,13 +145,13 @@
   <Config Name="[Vector Store:Elasticsearch] User" Target="ELASTICSEARCH_USER" Default="" Mode="" Description="Optional Elasticsearch username." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="[Vector Store:Elasticsearch] Password" Target="ELASTICSEARCH_PASSWORD" Default="" Mode="" Description="Optional Elasticsearch password." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="[Vector Store:Elasticsearch] Use SSL" Target="ELASTICSEARCH_USE_SSL" Default="true|false" Mode="" Description="Whether the Elasticsearch HTTP endpoint uses HTTPS. Default is true because modern Elasticsearch containers usually expose HTTPS." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
-  <Config Name="[Vector Store:Elasticsearch] Verify Certs" Target="ELASTICSEARCH_VERIFY_CERTS" Default="true|false" Mode="" Description="Whether to verify Elasticsearch TLS certificates. Default is false because many self-hosted homelab deployments use self-signed certs." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="[Vector Store:Elasticsearch] Verify Certs" Target="ELASTICSEARCH_VERIFY_CERTS" Default="true|false" Mode="" Description="Whether to verify Elasticsearch TLS certificates. Keep true for external HTTPS backends; set false only for a trusted self-signed endpoint on a private network." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
   <Config Name="[Vector Store:OpenSearch] Host" Target="OPENSEARCH_HOST" Default="" Mode="" Description="Optional external OpenSearch host." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="[Vector Store:OpenSearch] Port" Target="OPENSEARCH_PORT" Default="" Mode="" Description="Optional external OpenSearch port." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="[Vector Store:OpenSearch] User" Target="OPENSEARCH_USER" Default="" Mode="" Description="Optional OpenSearch username." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="[Vector Store:OpenSearch] Password" Target="OPENSEARCH_PASSWORD" Default="" Mode="" Description="Optional OpenSearch password." Type="Variable" Display="advanced" Required="false" Mask="true"/>
   <Config Name="[Vector Store:OpenSearch] Use SSL" Target="OPENSEARCH_USE_SSL" Default="true|false" Mode="" Description="Whether the OpenSearch HTTP endpoint uses HTTPS. Default is true because modern OpenSearch containers usually expose HTTPS." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
-  <Config Name="[Vector Store:OpenSearch] Verify Certs" Target="OPENSEARCH_VERIFY_CERTS" Default="true|false" Mode="" Description="Whether to verify OpenSearch TLS certificates. Leave false for self-signed homelab deployments." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="[Vector Store:OpenSearch] Verify Certs" Target="OPENSEARCH_VERIFY_CERTS" Default="true|false" Mode="" Description="Whether to verify OpenSearch TLS certificates. Keep true for external HTTPS backends; set false only for a trusted self-signed endpoint on a private network." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
   <Config Name="[Vector Store:FAISS] Path" Target="FAISS_PATH" Default="" Mode="" Description="Optional FAISS storage path inside the container or a mounted host path." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 
   <Config Name="[Backup Export] User ID Filter" Target="EXPORT_USER_ID" Default="" Mode="" Description="Optional one-shot filter for the bundled upstream export helper script. Only set this if you intentionally run the export tooling inside the container." Type="Variable" Display="advanced" Required="false" Mask="false"/>

--- a/rootfs/etc/cont-init.d/01-bootstrap.sh
+++ b/rootfs/etc/cont-init.d/01-bootstrap.sh
@@ -10,6 +10,7 @@ mkdir -p /mem0/storage
 export USER="${USER:-default_user}"
 export NEXT_PUBLIC_USER_ID="${NEXT_PUBLIC_USER_ID:-${USER}}"
 export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-/openmemory-api}"
+export MEM0_API_HOST="${MEM0_API_HOST:-127.0.0.1}"
 export DATABASE_URL="${DATABASE_URL:-sqlite:////mem0/storage/openmemory.db}"
 export QDRANT_HOST="${QDRANT_HOST:-127.0.0.1}"
 export QDRANT_PORT="${QDRANT_PORT:-6333}"
@@ -18,12 +19,19 @@ export OPENAI_API_KEY="${OPENAI_API_KEY-}"
 
 mem0_validate_vector_store_config
 
+for provider_var in LLM_PROVIDER EMBEDDER_PROVIDER; do
+	if [[ ${!provider_var-} == "auto" ]]; then
+		unset "${provider_var}"
+	fi
+done
+
 : >/var/run/mem0-aio.env
 
 runtime_env_vars=(
 	USER
 	NEXT_PUBLIC_USER_ID
 	NEXT_PUBLIC_API_URL
+	MEM0_API_HOST
 	DATABASE_URL
 	QDRANT_URL
 	QDRANT_HOST

--- a/rootfs/etc/services.d/fastapi/run
+++ b/rootfs/etc/services.d/fastapi/run
@@ -17,4 +17,4 @@ if ! mem0_uses_external_vector_store; then
 fi
 
 cd /app/api
-exec uvicorn main:app --host 0.0.0.0 --port 8765
+exec uvicorn main:app --host "${MEM0_API_HOST:-127.0.0.1}" --port 8765

--- a/tests/integration/test_backend_matrix.py
+++ b/tests/integration/test_backend_matrix.py
@@ -414,6 +414,8 @@ def backend_runtime(backend: str, image_tag: str):
             f"{ui_port}:3000",
             "-p",
             f"{api_port}:8765",
+            "-e",
+            "MEM0_API_HOST=0.0.0.0",
             "-v",
             f"{storage_path}:/mem0/storage",
             *mem0_env_args(backend, backend_container),

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -72,6 +72,8 @@ def container(storage_volume: str):
         f"{ui_port}:3000",
         "-p",
         f"{api_port}:8765",
+        "-e",
+        "MEM0_API_HOST=0.0.0.0",
         "-p",
         f"{qdrant_port}:6333",
         "-v",

--- a/tests/template/test_security_defaults.py
+++ b/tests/template/test_security_defaults.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from tests.conftest import REPO_ROOT
+
+
+def _template_configs() -> dict[str, ET.Element]:
+    root = ET.parse(REPO_ROOT / "mem0-aio.xml").getroot()
+    return {config.attrib["Name"]: config for config in root.findall("Config")}
+
+
+def test_api_mcp_port_is_not_published_by_default() -> None:
+    root = ET.parse(REPO_ROOT / "mem0-aio.xml").getroot()
+    published_ports = {
+        (
+            port.findtext("HostPort", default=""),
+            port.findtext("ContainerPort", default=""),
+        )
+        for port in root.findall("./Networking/Publish/Port")
+    }
+    configs = _template_configs()
+
+    assert ("3000", "3000") in published_ports  # nosec B101
+    assert ("8765", "8765") not in published_ports  # nosec B101
+
+    api_port = configs["API / MCP Port"]
+    assert api_port.attrib["Display"] == "advanced"  # nosec B101
+    assert api_port.attrib["Required"] == "false"  # nosec B101
+    assert api_port.attrib["Default"] == ""  # nosec B101
+    assert (api_port.text or "") == ""  # nosec B101
+
+    api_bind = configs["[Security] API Bind Address"]
+    assert api_bind.attrib["Target"] == "MEM0_API_HOST"  # nosec B101
+    assert api_bind.attrib["Default"] == "127.0.0.1"  # nosec B101
+    assert api_bind.text == "127.0.0.1"  # nosec B101
+
+
+def test_fastapi_binds_to_container_localhost_by_default() -> None:
+    run_script = (REPO_ROOT / "rootfs/etc/services.d/fastapi/run").read_text()
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+
+    assert '--host "${MEM0_API_HOST:-127.0.0.1}"' in run_script  # nosec B101
+    assert "--host 0.0.0.0" not in run_script  # nosec B101
+    assert "ENV MEM0_API_HOST=127.0.0.1" in dockerfile  # nosec B101
+    assert "EXPOSE 3000 6333" in dockerfile  # nosec B101
+    assert "EXPOSE 3000 8765 6333" not in dockerfile  # nosec B101
+
+
+def test_provider_auto_sentinel_is_unset_before_runtime_env_persistence() -> None:
+    bootstrap = (REPO_ROOT / "rootfs/etc/cont-init.d/01-bootstrap.sh").read_text()
+
+    assert "for provider_var in LLM_PROVIDER EMBEDDER_PROVIDER" in bootstrap  # nosec B101
+    assert '[[ ${!provider_var-} == "auto" ]]' in bootstrap  # nosec B101
+    assert 'unset "${provider_var}"' in bootstrap  # nosec B101
+
+
+def test_external_search_backends_verify_tls_by_default() -> None:
+    configs = _template_configs()
+
+    assert configs["[Vector Store:Elasticsearch] Verify Certs"].text == "true"  # nosec B101
+    assert configs["[Vector Store:OpenSearch] Verify Certs"].text == "true"  # nosec B101
+
+
+def test_dockerfile_rewrites_apt_sources_to_https_before_update() -> None:
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+
+    ca_index = dockerfile.index(
+        "COPY --from=qdrant-bin /etc/ssl/certs /etc/ssl/certs"
+    )
+    rewrite_index = dockerfile.index("sed -i 's|http://|https://|g'")
+    update_index = dockerfile.index("apt-get update")
+
+    assert ca_index < rewrite_index  # nosec B101
+    assert rewrite_index < update_index  # nosec B101
+    assert 'Acquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt"' in dockerfile  # nosec B101
+
+
+def test_openmemory_submodule_uses_official_upstream() -> None:
+    gitmodules = (REPO_ROOT / ".gitmodules").read_text()
+    app_manifest = (REPO_ROOT / ".aio-fleet.yml").read_text()
+
+    assert "url = https://github.com/mem0ai/mem0" in gitmodules  # nosec B101
+    assert "url = https://github.com/JSONbored/mem0" not in gitmodules  # nosec B101
+    assert "submodule_ref_template" not in app_manifest  # nosec B101


### PR DESCRIPTION
## Summary
- Harden mem0-aio runtime, template, Dockerfile, and submodule defaults against the reported exposure and supply-chain findings.

## What changed
- Restore OpenMemory submodule origin to `https://github.com/mem0ai/mem0`.
- Treat `LLM_PROVIDER=auto` and `EMBEDDER_PROVIDER=auto` as unset before persisting runtime env.
- Default Elasticsearch/OpenSearch TLS certificate verification to `true`.
- Restore HTTPS apt source enforcement before the first `apt-get update` and seed apt with a verified CA store.
- Default the API/MCP service to `127.0.0.1`, stop publishing host port `8765` by default, and document the explicit opt-in path.
- Update Docker integration tests that intentionally map the direct API port to set `MEM0_API_HOST=0.0.0.0`.

## Why
- These changes close the default API/MCP exposure, insecure TLS backend defaults, provider sentinel persistence, HTTP apt transport regression, and OpenMemory fork provenance risk.

## Validation
- `/Users/shadowbook/.codex/worktrees/security-2026-05-09/aio-fleet/.venv/bin/python -m pytest -q tests/template` -> `11 passed`
- `docker build --progress=plain --platform linux/amd64 -t mem0-aio:pytest .` -> passed
- `/Users/shadowbook/.codex/worktrees/security-2026-05-09/aio-fleet/.venv/bin/python -m pytest -q` -> `22 passed`
- `aio-fleet validate-repo --repo mem0-aio` against this worktree -> passed

## Notes
- Catalog sync is handled separately in `awesome-unraid` after this source XML change.
