### PR TITLE
fix(build): stabilize mem0 arm64 apt bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
-RUN printf 'Acquire::Retries "5";\nAcquire::Queue-Mode "access";\nAcquire::http::Timeout "60";\nAcquire::https::Timeout "60";\nAcquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries && \
+RUN printf 'Acquire::Retries "5";\nAcquire::Queue-Mode "host";\nAcquire::ForceIPv4 "true";\nAcquire::http::Pipeline-Depth "0";\nAcquire::https::Pipeline-Depth "0";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt";\nAcquire::https::Verify-Peer "true";\nAcquire::https::Verify-Host "true";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries && \
     find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|http://|https://|g' {} + && \
     apt_update_ok=0 && \
     for attempt in 1 2 3 4 5; do \

--- a/tests/integration/test_backend_matrix.py
+++ b/tests/integration/test_backend_matrix.py
@@ -38,6 +38,14 @@ INVALID_LOG_MARKERS = (
     "You didn't provide an API key",
     "Error categorizing memory",
 )
+PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
 
 
 def http_request(
@@ -121,6 +129,10 @@ def backend_ready(backend: str, backend_container: str, api_port: int) -> bool:
                     "docker",
                     "exec",
                     backend_container,
+                    "env",
+                    *[f"{name}=" for name in PROXY_ENV_VARS],
+                    "NO_PROXY=*",
+                    "no_proxy=*",
                     "wget",
                     "-qO-",
                     "http://127.0.0.1:8080/v1/.well-known/ready",
@@ -136,6 +148,10 @@ def backend_ready(backend: str, backend_container: str, api_port: int) -> bool:
                     "docker",
                     "exec",
                     backend_container,
+                    "env",
+                    *[f"{name}=" for name in PROXY_ENV_VARS],
+                    "NO_PROXY=*",
+                    "no_proxy=*",
                     "curl",
                     "-fsSk",
                     "-u",
@@ -153,6 +169,10 @@ def backend_ready(backend: str, backend_container: str, api_port: int) -> bool:
                     "docker",
                     "exec",
                     backend_container,
+                    "env",
+                    *[f"{name}=" for name in PROXY_ENV_VARS],
+                    "NO_PROXY=*",
+                    "no_proxy=*",
                     "curl",
                     "-fsSk",
                     "-u",
@@ -295,6 +315,14 @@ def backend_run_command(
 
 
 def mem0_env_args(backend: str, backend_container: str) -> list[str]:
+    proxy_bypass = ",".join(
+        [
+            "127.0.0.1",
+            "localhost",
+            OLLAMA_CONTAINER,
+            backend_container,
+        ]
+    )
     env_args = [
         "-e",
         f"OLLAMA_BASE_URL=http://{OLLAMA_CONTAINER}:11434",
@@ -302,7 +330,13 @@ def mem0_env_args(backend: str, backend_container: str) -> list[str]:
         "LLM_MODEL=tinyllama:latest",
         "-e",
         "EMBEDDER_MODEL=nomic-embed-text:latest",
+        "-e",
+        f"NO_PROXY={proxy_bypass}",
+        "-e",
+        f"no_proxy={proxy_bypass}",
     ]
+    for name in PROXY_ENV_VARS:
+        env_args.extend(["-e", f"{name}="])
     if backend == "faiss":
         env_args.extend(["-e", "FAISS_PATH=/mem0/storage/faiss"])
     elif backend == "qdrant-auth":

--- a/tests/template/test_security_defaults.py
+++ b/tests/template/test_security_defaults.py
@@ -82,11 +82,35 @@ def test_dockerfile_rewrites_apt_sources_to_https_before_update() -> None:
     assert (  # nosec B101
         'Acquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt"' in dockerfile
     )
+    assert 'Acquire::Queue-Mode "host"' in dockerfile  # nosec B101
+    assert 'Acquire::ForceIPv4 "true"' in dockerfile  # nosec B101
+    assert 'Acquire::https::Pipeline-Depth "0"' in dockerfile  # nosec B101
+    assert 'Acquire::https::Verify-Peer "true"' in dockerfile  # nosec B101
+    assert 'Acquire::https::Verify-Host "true"' in dockerfile  # nosec B101
     assert 'APT::Update::Error-Mode "any"' in dockerfile  # nosec B101
-    assert 'Acquire::Queue-Mode "access"' in dockerfile  # nosec B101
     assert "apt_update_ok=0" in dockerfile  # nosec B101
     assert 'test "${apt_update_ok}" = "1"' in dockerfile  # nosec B101
     assert "unable to resolve apt package version" in dockerfile  # nosec B101
+
+
+def test_backend_matrix_bypasses_host_proxy_for_internal_services() -> None:
+    from tests.integration.test_backend_matrix import mem0_env_args
+
+    backend_matrix = (
+        REPO_ROOT / "tests/integration/test_backend_matrix.py"
+    ).read_text()
+    env_args = mem0_env_args("redis", "mem0-backend-redis-test")
+    expected = "127.0.0.1,localhost,mem0-aio-ollama-mock,mem0-backend-redis-test"
+
+    assert f"NO_PROXY={expected}" in env_args  # nosec B101
+    assert f"no_proxy={expected}" in env_args  # nosec B101
+    assert "HTTP_PROXY=" in env_args  # nosec B101
+    assert "HTTPS_PROXY=" in env_args  # nosec B101
+    assert "ALL_PROXY=" in env_args  # nosec B101
+    assert '"NO_PROXY=*"' in backend_matrix  # nosec B101
+    assert '"no_proxy=*"' in backend_matrix  # nosec B101
+    assert "PROXY_ENV_VARS" in backend_matrix  # nosec B101
+    assert 'f"{name}="' in backend_matrix  # nosec B101
 
 
 def test_openmemory_submodule_uses_official_upstream() -> None:


### PR DESCRIPTION
## Summary
- harden the Ubuntu apt bootstrap used by the mem0 image build on arm64
- keep HTTPS apt verification while serializing apt access, forcing IPv4, and disabling pipelining
- isolate Docker integration tests from host/OrbStack proxy injection for internal backend traffic

## Why
The central publish path was failing/hanging in the linux/arm64 build during HTTPS apt index refresh from ports.ubuntu.com. The previous security hardening correctly restored HTTPS apt sources, but the arm64/QEMU publish environment needed stricter apt transport settings instead of a retry loop that could still stall.

## Validation
- uv run --with pytest --with defusedxml pytest tests/template/test_security_defaults.py -> 7 passed
- uv run --with pytest --with defusedxml pytest tests/integration/test_backend_matrix.py::test_external_backend_matrix_persists_memory_across_restart[qdrant] -> 1 passed
- uv run --with pytest --with defusedxml pytest tests/integration/test_backend_matrix.py::test_external_backend_matrix_persists_memory_across_restart[weaviate] -> 1 passed
- uv run --with pytest --with defusedxml pytest -> 23 passed
- docker buildx build --progress=plain --platform linux/arm64 --load -t mem0-aio:arm64-aptfix . -> passed
- python -m aio_fleet.cli validate-repo --repo mem0-aio --repo-path /Users/shadowbook/.codex/worktrees/security-2026-05-09/mem0-aio -> passed
- python -m aio_fleet.cli trunk run --repo mem0-aio --repo-path /Users/shadowbook/.codex/worktrees/security-2026-05-09/mem0-aio --no-fix -> trunk=ok
- git diff --check -> passed

## Notes
No release tag is created here; this is a publish-path fix so the existing central package publish can complete for the current main build.
