### PR TITLE
test(smoke): declare mem0 security test dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+defusedxml>=0.7.1
+pytest>=8.0


### PR DESCRIPTION
## Summary
- declares the test dependencies needed by mem0-aio security/defaults tests

## What changed
- adds requirements-dev.txt with pytest and defusedxml

## Why
- keeps security-default tests collectable in clean local or CI environments instead of relying on globally installed packages

## Validation
- uv run --with pytest --with defusedxml python -m pytest tests/template/test_security_defaults.py -q
- uv run --with pytest --with defusedxml python -m pytest tests/template -q
- central aio-fleet validate-repo against /Users/shadowbook/Documents/mem0-aio

## Notes
- no container runtime, XML template, or release artifact changed.