### PR TITLE
fix(build): restrict mem0 apt sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,13 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Keep Ubuntu's signed archive URIs intact. Ports images use HTTP by default,
-# and APT verifies signed InRelease metadata before installing packages.
+# and APT verifies signed, fresh InRelease metadata before installing packages.
 # hadolint ignore=DL3008
-RUN printf 'Acquire::Retries "3";\nAcquire::Queue-Mode "host";\nAcquire::ForceIPv4 "true";\nAcquire::http::Pipeline-Depth "0";\nAcquire::https::Pipeline-Depth "0";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt";\nAcquire::https::Verify-Peer "true";\nAcquire::https::Verify-Host "true";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries && \
+RUN printf 'Acquire::Retries "3";\nAcquire::Queue-Mode "host";\nAcquire::ForceIPv4 "true";\nAcquire::http::Pipeline-Depth "0";\nAcquire::https::Pipeline-Depth "0";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt";\nAcquire::https::Verify-Peer "true";\nAcquire::https::Verify-Host "true";\nAcquire::Check-Valid-Until "true";\nAcquire::AllowInsecureRepositories "false";\nAcquire::AllowDowngradeToInsecureRepositories "false";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries && \
     grep -Rqs '^Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' /etc/apt && \
+    if grep -RqsE '(^|[[:space:]])(Trusted:[[:space:]]*yes|Allow-Insecure:[[:space:]]*yes|Allow-Downgrade-To-Insecure:[[:space:]]*yes|trusted=yes|allow-insecure=yes|allow-downgrade-to-insecure=yes)([[:space:]]|$)' /etc/apt; then \
+        echo "insecure apt source option is not allowed" >&2; exit 1; \
+    fi && \
     apt_source_uris="$( \
         find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec awk ' \
             $1 == "URIs:" { for (i = 2; i <= NF; i++) print $i } \
@@ -55,8 +58,8 @@ RUN printf 'Acquire::Retries "3";\nAcquire::Queue-Mode "host";\nAcquire::ForceIP
     )" && \
     for uri in ${apt_source_uris}; do \
         case "${uri}" in \
-            https://*|http://archive.ubuntu.com/ubuntu/|http://security.ubuntu.com/ubuntu/|http://ports.ubuntu.com/ubuntu-ports/) ;; \
-            *) echo "unsupported plaintext apt source: ${uri}" >&2; exit 1 ;; \
+            http://archive.ubuntu.com/ubuntu/|http://security.ubuntu.com/ubuntu/|http://ports.ubuntu.com/ubuntu-ports/|https://archive.ubuntu.com/ubuntu/|https://security.ubuntu.com/ubuntu/|https://ports.ubuntu.com/ubuntu-ports/) ;; \
+            *) echo "unsupported apt source: ${uri}" >&2; exit 1 ;; \
         esac; \
     done && \
     apt_update_ok=0 && \

--- a/tests/template/test_security_defaults.py
+++ b/tests/template/test_security_defaults.py
@@ -68,11 +68,11 @@ def test_external_search_backends_verify_tls_by_default() -> None:
     )
 
 
-def test_dockerfile_preserves_signed_ubuntu_apt_sources() -> None:
+def test_dockerfile_restricts_apt_sources_without_forcing_https() -> None:
     dockerfile = (REPO_ROOT / "Dockerfile").read_text()
 
     ca_index = dockerfile.index("COPY --from=qdrant-bin /etc/ssl/certs /etc/ssl/certs")
-    source_guard_index = dockerfile.index("unsupported plaintext apt source")
+    source_guard_index = dockerfile.index("unsupported apt source")
     update_index = dockerfile.index("apt-get update")
     install_index = dockerfile.index("apt-get install -y --no-install-recommends")
 
@@ -91,11 +91,21 @@ def test_dockerfile_preserves_signed_ubuntu_apt_sources() -> None:
     assert 'Acquire::https::Timeout "20"' in dockerfile  # nosec B101
     assert 'Acquire::https::Verify-Peer "true"' in dockerfile  # nosec B101
     assert 'Acquire::https::Verify-Host "true"' in dockerfile  # nosec B101
+    assert 'Acquire::Check-Valid-Until "true"' in dockerfile  # nosec B101
+    assert 'Acquire::AllowInsecureRepositories "false"' in dockerfile  # nosec B101
+    assert (  # nosec B101
+        'Acquire::AllowDowngradeToInsecureRepositories "false"' in dockerfile
+    )
     assert 'APT::Update::Error-Mode "any"' in dockerfile  # nosec B101
     assert "ubuntu-archive-keyring.gpg" in dockerfile  # nosec B101
+    assert "insecure apt source option is not allowed" in dockerfile  # nosec B101
     assert "http://archive.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
     assert "http://security.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
     assert "http://ports.ubuntu.com/ubuntu-ports/" in dockerfile  # nosec B101
+    assert "https://archive.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
+    assert "https://security.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
+    assert "https://ports.ubuntu.com/ubuntu-ports/" in dockerfile  # nosec B101
+    assert "https://*|" not in dockerfile  # nosec B101
     assert "sed -i 's|http://|https://|g'" not in dockerfile  # nosec B101
     assert "apt_update_ok=0" in dockerfile  # nosec B101
     assert 'test "${apt_update_ok}" = "1"' in dockerfile  # nosec B101


### PR DESCRIPTION
## Summary
- tighten the first apt bootstrap source guard without forcing Ubuntu archive HTTPS
- keep official Ubuntu archive/security/ports sources working for multi-arch builds
- explicitly reject insecure apt source options and arbitrary apt source roots before apt-get update

## Why
- forcing HTTPS previously made mem0 package/release builds fragile, especially around Ubuntu ports/security apt behavior
- APT verifies signed InRelease metadata and package hashes, so the safer operational fix is to constrain trust to signed official Ubuntu sources rather than rewrite transport blindly

## Validation
- .venv/bin/python -m pytest -q tests/template
- aio-fleet validate-repo --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio
- aio-fleet validate-template-common --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio
- aio-fleet control-check --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio --sha 996072567cf3eb84a682c0fd8f53a01a8960cdeb --event pull_request
