### PR TITLE
chore(release): v2.0.1-aio.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.1-aio.3 - 2026-05-10
+
+### Fixes
+
+- Restrict mem0 apt sources
+
+### Tests
+
+- Declare mem0 security test dependencies
+
 ## v2.0.1-aio.2 - 2026-05-10
 
 ### Fixes

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -33,11 +33,8 @@
 - The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
   <Changes>### 2026-05-10&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Tighten mem0 runtime defaults&#xD;
-- Satisfy mem0 central trunk policy&#xD;
-- Harden mem0 apt bootstrap retries&#xD;
-- Stabilize mem0 arm64 apt bootstrap&#xD;
-- Preserve signed Ubuntu apt sources</Changes>
+- Restrict mem0 apt sources&#xD;
+- Declare mem0 security test dependencies</Changes>
   <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare the v2.0.1-aio.3 release metadata after the apt-source hardening fix
- sync CHANGELOG.md and the Unraid XML Changes block

## What changed
- added v2.0.1-aio.3 changelog notes
- updated mem0-aio.xml release notes shown in Community Apps metadata

## Why
- the apt-source hardening affects the published image build path and should have an immutable AIO release/package tag

## Validation
- .venv/bin/python -m pytest -q tests/template
- aio-fleet validate-repo --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio
- aio-fleet validate-template-common --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio
