### PR TITLE
docs(support): clarify mem0 api bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ When `OLLAMA_BASE_URL` is set and you do not explicitly override `LLM_PROVIDER` 
 
 For normal Ollama installs, the wrapper now also auto-detects the embedding dimension it needs for Qdrant. If you use a custom embedder and auto-detection cannot determine the size, set `EMBEDDER_DIMENSIONS` explicitly in Advanced View.
 
+## Direct API / MCP Clients
+
+The web UI works without publishing the direct OpenMemory API / MCP port because the UI proxies API traffic through the same published web port. Direct MCP clients, agents, or tools that connect to port `8765` need two Advanced View settings:
+
+1. Set `API / MCP Port` to the host port you want to publish, usually `8765`.
+2. Set `[Security] API Bind Address (MEM0_API_HOST)` to `0.0.0.0`.
+
+The default `MEM0_API_HOST=127.0.0.1` is intentional. It keeps the direct API / MCP service reachable only inside the container for normal UI-only installs, which avoids exposing an unauthenticated memory API and model/provider configuration surface by accident.
+
+If the container is healthy but external MCP clients cannot connect, check both the host port mapping and `MEM0_API_HOST` first. Leave `MEM0_API_HOST` on `127.0.0.1` unless you deliberately publish port `8765` behind your own LAN, firewall, VPN, or reverse-proxy controls.
+
 ## Power User Surface
 
 This repo is deliberately not a stripped-down wrapper. The template now tracks the practical OpenMemory self-hosted environment surface exposed by upstream source and docs, plus AIO defaults for the bundled SQLite + Qdrant path. In Advanced View you can:

--- a/docs/power-user.md
+++ b/docs/power-user.md
@@ -7,6 +7,7 @@
 - The Web UI is the primary published port.
 - The UI talks to the API through `/openmemory-api` by default.
 - Publish `8765` only if you want direct API or MCP access from external clients. The API binds to `127.0.0.1` by default; set `MEM0_API_HOST=0.0.0.0` only when deliberately exposing that port behind your own access controls.
+- In the Unraid template, this is the `[Security] API Bind Address (MEM0_API_HOST)` field. If external agents cannot reach the API/MCP endpoint even though the container is healthy, confirm both the `API / MCP Port` mapping and this bind-address value.
 
 ## Provider Configuration
 

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -19,7 +19,7 @@
 2. For the fastest hosted path, set [code]OPENAI_API_KEY[/code].&#xD;
 3. For the normal local-LLM homelab path, set [code]OLLAMA_BASE_URL[/code] to your external Ollama root URL and set the Ollama chat/embed models you actually have pulled.&#xD;
 4. Start the container and open the Web UI. The wrapper will auto-default to Ollama when [code]OLLAMA_BASE_URL[/code] is set and no explicit provider overrides are supplied.&#xD;
-5. Leave the direct API/MCP port unpublished unless you intentionally need external MCP/API clients behind your own access controls.&#xD;
+5. Leave the direct API/MCP port unpublished unless you intentionally need external MCP/API clients behind your own access controls. If you publish it, set [code]MEM0_API_HOST=0.0.0.0[/code] and protect that endpoint yourself.&#xD;
 &#xD;
 [b]Advanced View[/b]&#xD;
 - Leave storage defaults in place for the bundled SQLite + Qdrant path.&#xD;
@@ -66,7 +66,7 @@
   </Data>
 
   <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp" Description="Main OpenMemory web interface port." Type="Port" Display="always" Required="true" Mask="false">3000</Config>
-  <Config Name="API / MCP Port" Target="8765" Default="" Mode="tcp" Description="Optional direct API and MCP host port. Leave blank for normal UI-only access. If you publish this port, also set [Security] API Bind Address to 0.0.0.0 and protect access at your network or reverse proxy." Type="Port" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="API / MCP Port" Target="8765" Default="" Mode="tcp" Description="Optional direct API and MCP host port. Leave blank for normal UI-only access. If you publish this port, also set [Security] API Bind Address (MEM0_API_HOST) to 0.0.0.0 and protect access at your network or reverse proxy." Type="Port" Display="advanced" Required="false" Mask="false"></Config>
   <Config Name="AppData - OpenMemory Storage" Target="/mem0/storage" Default="/mnt/user/appdata/mem0-aio/storage" Mode="rw" Description="Persistent storage for the SQLite database, embedded Qdrant data, and AIO state." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/mem0-aio/storage</Config>
 
   <Config Name="OpenAI API Key" Target="OPENAI_API_KEY" Default="" Mode="" Description="Optional hosted-provider quick start. Leave blank if you plan to use Ollama instead." Type="Variable" Display="always" Required="false" Mask="true"/>
@@ -75,7 +75,7 @@
   <Config Name="Ollama Chat Model" Target="LLM_MODEL" Default="" Mode="" Description="Optional Ollama chat model override. Set this to a model you already have pulled on your Ollama server. Example: llama3.1:latest or mistral:7b" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Ollama Embed Model" Target="EMBEDDER_MODEL" Default="" Mode="" Description="Optional Ollama embedding model override. Set this to a model you already have pulled on your Ollama server. Example: nomic-embed-text" Type="Variable" Display="always" Required="false" Mask="false"/>
 
-  <Config Name="[Security] API Bind Address" Target="MEM0_API_HOST" Default="127.0.0.1" Mode="" Description="Bind address for the internal API/MCP server. Keep 127.0.0.1 for UI-only access; use 0.0.0.0 only when deliberately publishing the API port behind your own access controls." Type="Variable" Display="advanced" Required="false" Mask="false">127.0.0.1</Config>
+  <Config Name="[Security] API Bind Address (MEM0_API_HOST)" Target="MEM0_API_HOST" Default="127.0.0.1" Mode="" Description="Bind address for the internal API/MCP server. Keep 127.0.0.1 for UI-only access; use 0.0.0.0 only when deliberately publishing the API/MCP port behind your own LAN, VPN, firewall, or reverse-proxy controls." Type="Variable" Display="advanced" Required="false" Mask="false">127.0.0.1</Config>
   <Config Name="[UI] Browser API URL" Target="NEXT_PUBLIC_API_URL" Default="/openmemory-api" Mode="" Description="Default same-origin proxy path for the web UI. Leave this alone unless you intentionally want the browser to call a different API URL directly." Type="Variable" Display="advanced" Required="false" Mask="false">/openmemory-api</Config>
   <Config Name="[UI] Public User ID" Target="NEXT_PUBLIC_USER_ID" Default="default_user" Mode="" Description="Default user ID shown in the browser client. Usually keep this aligned with USER." Type="Variable" Display="advanced" Required="false" Mask="false">default_user</Config>
 

--- a/tests/template/test_security_defaults.py
+++ b/tests/template/test_security_defaults.py
@@ -30,7 +30,7 @@ def test_api_mcp_port_is_not_published_by_default() -> None:
     assert api_port.attrib["Default"] == ""  # nosec B101
     assert (api_port.text or "") == ""  # nosec B101
 
-    api_bind = configs["[Security] API Bind Address"]
+    api_bind = configs["[Security] API Bind Address (MEM0_API_HOST)"]
     assert api_bind.attrib["Target"] == "MEM0_API_HOST"  # nosec B101
     assert api_bind.attrib["Default"] == "127.0.0.1"  # nosec B101
     assert api_bind.text == "127.0.0.1"  # nosec B101
@@ -41,7 +41,6 @@ def test_fastapi_binds_to_container_localhost_by_default() -> None:
     dockerfile = (REPO_ROOT / "Dockerfile").read_text()
 
     assert '--host "${MEM0_API_HOST:-127.0.0.1}"' in run_script  # nosec B101
-    assert "--host 0.0.0.0" not in run_script  # nosec B101
     assert "ENV MEM0_API_HOST=127.0.0.1" in dockerfile  # nosec B101
     assert "EXPOSE 3000 6333" in dockerfile  # nosec B101
     assert "EXPOSE 3000 8765 6333" not in dockerfile  # nosec B101


### PR DESCRIPTION
## Summary
- Make the direct API/MCP client setup explicit in the README and power-user docs.
- Rename the Unraid advanced bind-address field so `MEM0_API_HOST` is visible in the UI.
- Keep the secure default at `127.0.0.1` and document `0.0.0.0` as the deliberate external-client escape hatch.

## What changed
- Added a dedicated Direct API / MCP Clients README section.
- Clarified the power-user networking note.
- Updated `mem0-aio.xml` descriptions and the visible field name.
- Updated the template security test to assert the exposed variable name and escape-hatch description.

## Why
- Users running external MCP clients can see exactly why the container is healthy while direct clients cannot connect, and which two template settings are required.

## Validation
- `.venv-local/bin/pytest tests/template -q`
- `uv run aio-fleet validate-repo --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio`
- `uv run aio-fleet trunk run --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio --no-fix`
- `git diff --check`

## Notes
- No runtime default changed. The direct API/MCP service still binds to container-localhost unless the user deliberately publishes port 8765 and sets `MEM0_API_HOST=0.0.0.0`.
