### PR TITLE
chore(release): v2.0.2-aio.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.2-aio.2 - 2026-05-17
+
+### Documentation
+
+- Clarify Mem0 API bind address
+
 ## v2.0.2-aio.1 - 2026-05-17
 
 ### Maintenance

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -33,7 +33,7 @@
 - The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
   <Changes>### 2026-05-17&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Bump mem0 to v2.0.2</Changes>
+- Clarify Mem0 API bind address</Changes>
   <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare the Mem0 AIO v2.0.2-aio.2 release

## What changed
- add the v2.0.2-aio.2 changelog entry
- sync the Unraid template Changes block from the release changelog

## Why
- the Mem0 API bind-address documentation/template fix has landed on main and needs a formal release so packages publish for the merged commit

## Validation
- .venv-local/bin/pytest tests/template -q
- .venv-local/bin/pytest tests/integration -m integration -q
- uv run aio-fleet validate-repo --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio
- uv run aio-fleet trunk run --repo mem0-aio --repo-path /Users/shadowbook/Documents/mem0-aio --no-fix
- git diff --check