### PR TITLE
chore(cleanup): remove repo-local test deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-defusedxml>=0.7.1
-pytest>=8.0


### PR DESCRIPTION
## Summary
- Removes the legacy repo-local test dependency file now supplied by aio-fleet.

## What changed
- Deletes `requirements-dev.txt`.

## Why
- Shared app-test dependencies are installed centrally by aio-fleet, so the local file is stale cleanup drift.

## Validation
- `python -m aio_fleet validate-repo --repo mem0-aio --repo-path <repo>`
- `git diff --check`