### PR TITLE
fix(build): harden mem0 apt and upstream provenance

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -31,7 +31,6 @@ upstream:
       release_notes_url: https://github.com/mem0ai/mem0/releases
       submodule_path: openmemory
       submodule_remote: origin
-      submodule_ref_template: codex/openmemory-{version}-aio
 template:
   xml_paths:
     - mem0-aio.xml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openmemory"]
 	path = openmemory
-	url = https://github.com/JSONbored/mem0
+	url = https://github.com/mem0ai/mem0

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,14 @@ RUN pnpm build || npm run build
 ARG UPSTREAM_VERSION=v2.0.2
 FROM qdrant/qdrant@sha256:94728574965d17c6485dd361aa3c0818b325b9016dac5ea6afec7b4b2700865f AS qdrant-bin
 
-FROM ubuntu:26.04@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4
+FROM ubuntu:26.04@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4 AS runtime-base
 ARG S6_OVERLAY_VERSION=3.2.0.0
 ARG TARGETARCH
 
 COPY --from=qdrant-bin /etc/ssl/certs /etc/ssl/certs
 COPY --from=qdrant-bin /etc/ca-certificates.conf /etc/ca-certificates.conf
 COPY --from=qdrant-bin /usr/share/ca-certificates /usr/share/ca-certificates
+COPY docker/normalize-apt-sources.sh /usr/local/bin/normalize-apt-sources
 
 # Install system dependencies, python, nodejs
 ENV DEBIAN_FRONTEND=noninteractive
@@ -38,30 +39,13 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# Keep Ubuntu's signed archive URIs intact. Ports images use HTTP by default,
-# and APT verifies signed, fresh InRelease metadata before installing packages.
+# Normalize only official Ubuntu archive URIs to HTTPS and fail closed before
+# package metadata is fetched.
 # hadolint ignore=DL3008
 RUN printf 'Acquire::Retries "3";\nAcquire::Queue-Mode "host";\nAcquire::ForceIPv4 "true";\nAcquire::http::Pipeline-Depth "0";\nAcquire::https::Pipeline-Depth "0";\nAcquire::http::Timeout "20";\nAcquire::https::Timeout "20";\nAcquire::https::CaInfo "/etc/ssl/certs/ca-certificates.crt";\nAcquire::https::Verify-Peer "true";\nAcquire::https::Verify-Host "true";\nAcquire::Check-Valid-Until "true";\nAcquire::AllowInsecureRepositories "false";\nAcquire::AllowDowngradeToInsecureRepositories "false";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries && \
+    chmod +x /usr/local/bin/normalize-apt-sources && \
     grep -Rqs '^Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' /etc/apt && \
-    if grep -RqsE '(^|[[:space:]])(Trusted:[[:space:]]*yes|Allow-Insecure:[[:space:]]*yes|Allow-Downgrade-To-Insecure:[[:space:]]*yes|trusted=yes|allow-insecure=yes|allow-downgrade-to-insecure=yes)([[:space:]]|$)' /etc/apt; then \
-        echo "insecure apt source option is not allowed" >&2; exit 1; \
-    fi && \
-    apt_source_uris="$( \
-        find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec awk ' \
-            $1 == "URIs:" { for (i = 2; i <= NF; i++) print $i } \
-            $1 == "deb" || $1 == "deb-src" { \
-                for (i = 2; i <= NF; i++) { \
-                    if ($i ~ /^https?:\/\//) { print $i; break } \
-                } \
-            } \
-        ' {} + \
-    )" && \
-    for uri in ${apt_source_uris}; do \
-        case "${uri}" in \
-            http://archive.ubuntu.com/ubuntu/|http://security.ubuntu.com/ubuntu/|http://ports.ubuntu.com/ubuntu-ports/|https://archive.ubuntu.com/ubuntu/|https://security.ubuntu.com/ubuntu/|https://ports.ubuntu.com/ubuntu-ports/) ;; \
-            *) echo "unsupported apt source: ${uri}" >&2; exit 1 ;; \
-        esac; \
-    done && \
+    /usr/local/bin/normalize-apt-sources && \
     apt_update_ok=0 && \
     for attempt in 1 2 3; do \
         if apt-get update; then apt_update_ok=1; break; fi; \
@@ -91,8 +75,15 @@ RUN printf 'Acquire::Retries "3";\nAcquire::Queue-Mode "host";\nAcquire::ForceIP
     apt-get install -y --no-install-recommends "${install_packages[@]}" \
     && rm -rf /var/lib/apt/lists/*
 
+FROM runtime-base AS runtime
+ARG S6_OVERLAY_VERSION=3.2.0.0
+ARG TARGETARCH
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install Node.js 24 to match the UI builder runtime.
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh && \
+    bash /tmp/nodesource_setup.sh && \
+    rm -f /tmp/nodesource_setup.sh && \
     apt-get install -y --no-install-recommends nodejs="$(apt-cache madison nodejs | awk 'NR==1 {print $3}')" && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/normalize-apt-sources.sh
+++ b/docker/normalize-apt-sources.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt_root="${1:-/}"
+apt_root="${apt_root%/}"
+apt_dir="${apt_root}/etc/apt"
+
+if [[ ! -d ${apt_dir} ]]; then
+	echo "apt directory not found: ${apt_dir}" >&2
+	exit 1
+fi
+
+if grep -RqsE '(^|[[:space:]])(Trusted:[[:space:]]*yes|Allow-Insecure:[[:space:]]*yes|Allow-Downgrade-To-Insecure:[[:space:]]*yes|trusted=yes|allow-insecure=yes|allow-downgrade-to-insecure=yes)([[:space:]]|$)' "${apt_dir}"; then
+	echo "insecure apt source option is not allowed" >&2
+	exit 1
+fi
+
+source_files="$(mktemp)"
+trap 'rm -f "${source_files}"' EXIT
+find "${apt_dir}" -type f \( -name '*.list' -o -name '*.sources' \) -print0 >"${source_files}"
+
+while IFS= read -r -d '' source_file; do
+	perl -0pi -e '
+        s{http://archive\.ubuntu\.com/ubuntu/}{https://archive.ubuntu.com/ubuntu/}g;
+        s{http://security\.ubuntu\.com/ubuntu/}{https://security.ubuntu.com/ubuntu/}g;
+        s{http://ports\.ubuntu\.com/ubuntu-ports/}{https://ports.ubuntu.com/ubuntu-ports/}g;
+    ' "${source_file}"
+done <"${source_files}"
+
+apt_source_uris="$(
+	find "${apt_dir}" -type f \( -name '*.list' -o -name '*.sources' \) -exec awk '
+        $1 == "URIs:" { for (i = 2; i <= NF; i++) print $i }
+        $1 == "deb" || $1 == "deb-src" {
+            for (i = 2; i <= NF; i++) {
+                if ($i ~ /^https?:\/\//) { print $i; break }
+            }
+        }
+    ' {} +
+)"
+
+for uri in ${apt_source_uris}; do
+	case "${uri}" in
+	https://archive.ubuntu.com/ubuntu/ | https://security.ubuntu.com/ubuntu/ | https://ports.ubuntu.com/ubuntu-ports/) ;;
+	http://*)
+		echo "plaintext apt source remained: ${uri}" >&2
+		exit 1
+		;;
+	*)
+		echo "unsupported apt source: ${uri}" >&2
+		exit 1
+		;;
+	esac
+done

--- a/tests/template/test_security_defaults.py
+++ b/tests/template/test_security_defaults.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess  # nosec B404
+from pathlib import Path
+
 from defusedxml import ElementTree as ET
 
 from tests.conftest import REPO_ROOT
@@ -67,14 +70,19 @@ def test_external_search_backends_verify_tls_by_default() -> None:
     )
 
 
-def test_dockerfile_restricts_apt_sources_without_forcing_https() -> None:
+def test_dockerfile_normalizes_apt_sources_before_update() -> None:
     dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+    normalizer = (REPO_ROOT / "docker/normalize-apt-sources.sh").read_text()
 
     ca_index = dockerfile.index("COPY --from=qdrant-bin /etc/ssl/certs /etc/ssl/certs")
-    source_guard_index = dockerfile.index("unsupported apt source")
+    source_guard_index = dockerfile.index("/usr/local/bin/normalize-apt-sources")
     update_index = dockerfile.index("apt-get update")
     install_index = dockerfile.index("apt-get install -y --no-install-recommends")
 
+    assert "FROM ubuntu:26.04@" in dockerfile  # nosec B101
+    assert " AS runtime-base" in dockerfile  # nosec B101
+    assert "FROM runtime-base AS runtime" in dockerfile  # nosec B101
+    assert "COPY docker/normalize-apt-sources.sh" in dockerfile  # nosec B101
     assert ca_index < source_guard_index  # nosec B101
     assert source_guard_index < update_index  # nosec B101
     assert update_index < install_index  # nosec B101
@@ -97,18 +105,98 @@ def test_dockerfile_restricts_apt_sources_without_forcing_https() -> None:
     )
     assert 'APT::Update::Error-Mode "any"' in dockerfile  # nosec B101
     assert "ubuntu-archive-keyring.gpg" in dockerfile  # nosec B101
-    assert "insecure apt source option is not allowed" in dockerfile  # nosec B101
-    assert "http://archive.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
-    assert "http://security.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
-    assert "http://ports.ubuntu.com/ubuntu-ports/" in dockerfile  # nosec B101
-    assert "https://archive.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
-    assert "https://security.ubuntu.com/ubuntu/" in dockerfile  # nosec B101
-    assert "https://ports.ubuntu.com/ubuntu-ports/" in dockerfile  # nosec B101
-    assert "https://*|" not in dockerfile  # nosec B101
+    assert "http://archive.ubuntu.com/ubuntu/|" not in dockerfile  # nosec B101
+    assert "http://security.ubuntu.com/ubuntu/|" not in dockerfile  # nosec B101
+    assert "http://ports.ubuntu.com/ubuntu-ports/|" not in dockerfile  # nosec B101
     assert "sed -i 's|http://|https://|g'" not in dockerfile  # nosec B101
     assert "apt_update_ok=0" in dockerfile  # nosec B101
     assert 'test "${apt_update_ok}" = "1"' in dockerfile  # nosec B101
     assert "unable to resolve apt package version" in dockerfile  # nosec B101
+    assert "insecure apt source option is not allowed" in normalizer  # nosec B101
+    assert "plaintext apt source remained" in normalizer  # nosec B101
+    assert "http://archive\\.ubuntu\\.com/ubuntu/" in normalizer  # nosec B101
+    assert "http://security\\.ubuntu\\.com/ubuntu/" in normalizer  # nosec B101
+    assert "http://ports\\.ubuntu\\.com/ubuntu-ports/" in normalizer  # nosec B101
+    assert "https://archive.ubuntu.com/ubuntu/" in normalizer  # nosec B101
+    assert "https://security.ubuntu.com/ubuntu/" in normalizer  # nosec B101
+    assert "https://ports.ubuntu.com/ubuntu-ports/" in normalizer  # nosec B101
+
+
+def _apt_source_root(tmp_path: Path) -> Path:
+    root = tmp_path / "apt-root"
+    (root / "etc/apt/sources.list.d").mkdir(parents=True)
+    return root
+
+
+def _run_apt_normalizer(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603
+        [str(REPO_ROOT / "docker/normalize-apt-sources.sh"), str(root)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_apt_normalizer_rewrites_official_sources_files(tmp_path: Path) -> None:
+    root = _apt_source_root(tmp_path)
+    deb822 = root / "etc/apt/sources.list.d/ubuntu.sources"
+    legacy = root / "etc/apt/sources.list.d/ports.list"
+    deb822.write_text(
+        "\n".join(
+            [
+                "Types: deb",
+                "URIs: http://archive.ubuntu.com/ubuntu/ http://security.ubuntu.com/ubuntu/",
+                "Suites: resolute resolute-updates resolute-security",
+                "Components: main universe",
+                "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+            ]
+        )
+        + "\n"
+    )
+    legacy.write_text("deb http://ports.ubuntu.com/ubuntu-ports/ resolute main\n")
+
+    result = _run_apt_normalizer(root)
+
+    assert result.returncode == 0, result.stderr  # nosec B101
+    assert "http://" not in deb822.read_text()  # nosec B101
+    assert "http://" not in legacy.read_text()  # nosec B101
+    assert "https://archive.ubuntu.com/ubuntu/" in deb822.read_text()  # nosec B101
+    assert "https://security.ubuntu.com/ubuntu/" in deb822.read_text()  # nosec B101
+    assert "https://ports.ubuntu.com/ubuntu-ports/" in legacy.read_text()  # nosec B101
+
+
+def test_apt_normalizer_rejects_remaining_plaintext_sources(tmp_path: Path) -> None:
+    root = _apt_source_root(tmp_path)
+    source = root / "etc/apt/sources.list.d/attacker.list"
+    source.write_text("deb http://attacker.invalid/ubuntu/ resolute main\n")
+
+    result = _run_apt_normalizer(root)
+
+    assert result.returncode != 0  # nosec B101
+    assert "plaintext apt source remained" in result.stderr  # nosec B101
+
+
+def test_apt_normalizer_rejects_insecure_source_options(tmp_path: Path) -> None:
+    root = _apt_source_root(tmp_path)
+    source = root / "etc/apt/sources.list.d/ubuntu.sources"
+    source.write_text(
+        "\n".join(
+            [
+                "Types: deb",
+                "URIs: http://archive.ubuntu.com/ubuntu/",
+                "Suites: resolute",
+                "Components: main",
+                "Trusted: yes",
+                "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+            ]
+        )
+        + "\n"
+    )
+
+    result = _run_apt_normalizer(root)
+
+    assert result.returncode != 0  # nosec B101
+    assert "insecure apt source option is not allowed" in result.stderr  # nosec B101
 
 
 def test_backend_matrix_bypasses_host_proxy_for_internal_services() -> None:
@@ -131,11 +219,10 @@ def test_backend_matrix_bypasses_host_proxy_for_internal_services() -> None:
     assert 'f"{name}="' in backend_matrix  # nosec B101
 
 
-def test_openmemory_submodule_uses_aio_patch_fork() -> None:
+def test_openmemory_submodule_uses_official_upstream() -> None:
     gitmodules = (REPO_ROOT / ".gitmodules").read_text()
     app_manifest = (REPO_ROOT / ".aio-fleet.yml").read_text()
 
-    assert "url = https://github.com/JSONbored/mem0" in gitmodules  # nosec B101
-    assert (  # nosec B101
-        "submodule_ref_template: codex/openmemory-{version}-aio" in app_manifest
-    )
+    assert "url = https://github.com/mem0ai/mem0" in gitmodules  # nosec B101
+    assert "url = https://github.com/JSONbored/mem0" not in gitmodules  # nosec B101
+    assert "submodule_ref_template" not in app_manifest  # nosec B101


### PR DESCRIPTION
## Summary
- harden Ubuntu APT source handling before package installation
- restore OpenMemory submodule provenance to the official upstream repository
- add regression coverage for APT normalization, plaintext source rejection, and provenance policy

## What changed
- Added a Docker APT normalizer that rewrites only official Ubuntu HTTP sources to HTTPS, rejects arbitrary HTTP sources, and blocks insecure APT options.
- Added a `runtime-base` target so the APT layer can be validated quickly across platforms.
- Removed the mutable OpenMemory fork ref template and pointed `.gitmodules` back to `mem0ai/mem0`.
- Expanded template security tests for `.sources`, `.list`, rejected sources, and Dockerfile ordering.

## Why
The previous build path could inherit or allow plaintext APT sources, and release automation trusted a mutable fork-specific OpenMemory branch. This keeps build inputs reviewed and transport-hardened before publish.

## Validation
- `.venv-local/bin/pytest -q tests/template`
- `aio-fleet validate-repo --repo mem0-aio`
- Probed official Ubuntu HTTPS APT endpoints
- `docker buildx build --target runtime-base --platform linux/amd64 --no-cache --progress=plain .`
- `docker buildx build --target runtime-base --platform linux/arm64 --no-cache --progress=plain .`
- Full local image build without push
- Isolated local container smoke on port 13080

## Notes
- No publish was run.
- Test containers, volumes, and networks used isolated `codex-*` resources and were cleaned up.