### PR TITLE
chore(release): v2.0.2-aio.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.2-aio.3 - 2026-05-19
+
+### Fixes
+
+- Harden mem0 apt and upstream provenance
+
+### Maintenance
+
+- Remove repo-local test deps
+
 ## v2.0.2-aio.2 - 2026-05-17
 
 ### Documentation

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -31,9 +31,10 @@
 - Actual memory generation still requires a valid LLM/embedder configuration. Leaving [code]OPENAI_API_KEY[/code] blank is fine if you are using Ollama, but you still need to provide a reachable Ollama endpoint and valid model names.&#xD;
 - Native Ollama uses the root API URL such as [code]http://host.docker.internal:11434[/code], not an OpenAI-compatible [code]/v1[/code] path. If your reverse proxy adds auth and only exposes an OpenAI-style [code]/v1[/code] endpoint, use the advanced OpenAI-compatible base URL fields instead of the native Ollama provider path.&#xD;
 - The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
-  <Changes>### 2026-05-17&#xD;
+  <Changes>### 2026-05-19&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Clarify Mem0 API bind address</Changes>
+- Harden mem0 apt and upstream provenance&#xD;
+- Remove repo-local test deps</Changes>
   <Category>AI: Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare `v2.0.2-aio.3`
- update source Unraid template `<Changes>` from the release notes

## Why
This publishes the merged APT/provenance hardening work as a formal Mem0-AIO package revision.

## Validation
- `python -m pytest tests/template`
- `python -m aio_fleet validate-repo --repo mem0-aio`
- `git diff --check`
