### PR TITLE
chore(release): v2.0.2-aio.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.2-aio.4 - 2026-05-26
+
+### Documentation
+
+- Normalize CA metadata
+
 ## v2.0.2-aio.3 - 2026-05-19
 
 ### Fixes

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -31,10 +31,9 @@
 - Actual memory generation still requires a valid LLM/embedder configuration. Leaving [code]OPENAI_API_KEY[/code] blank is fine if you are using Ollama, but you still need to provide a reachable Ollama endpoint and valid model names.&#xD;
 - Native Ollama uses the root API URL such as [code]http://host.docker.internal:11434[/code], not an OpenAI-compatible [code]/v1[/code] path. If your reverse proxy adds auth and only exposes an OpenAI-style [code]/v1[/code] endpoint, use the advanced OpenAI-compatible base URL fields instead of the native Ollama provider path.&#xD;
 - The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
-  <Changes>### 2026-05-19&#xD;
+  <Changes>### 2026-05-26&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Harden mem0 apt and upstream provenance&#xD;
-- Remove repo-local test deps</Changes>
+- Normalize CA metadata</Changes>
   <Category>AI Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Cut the v2.0.2-aio.4 release metadata.
- Update CHANGELOG.md and mem0-aio.xml <Changes> for the release.

## Validation
- `git diff --check`
- XML parse check for `mem0-aio.xml`
- `uv run --with pytest --with defusedxml python -m pytest -q tests/template`
- commit hook: Trunk and fleet policy checks passed
