### PR TITLE
chore(release): v2.0.5-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.5-aio.1 - 2026-06-12
+
+### Maintenance
+
+- Bump mem0 to v2.0.5 (#98)
+
+### Tests
+
+- Use shared app test helpers
+
 ## v2.0.4-aio.1 - 2026-05-28
 
 ### Maintenance

--- a/mem0-aio.xml
+++ b/mem0-aio.xml
@@ -31,9 +31,10 @@
 - Actual memory generation still requires a valid LLM/embedder configuration. Leaving [code]OPENAI_API_KEY[/code] blank is fine if you are using Ollama, but you still need to provide a reachable Ollama endpoint and valid model names.&#xD;
 - Native Ollama uses the root API URL such as [code]http://host.docker.internal:11434[/code], not an OpenAI-compatible [code]/v1[/code] path. If your reverse proxy adds auth and only exposes an OpenAI-style [code]/v1[/code] endpoint, use the advanced OpenAI-compatible base URL fields instead of the native Ollama provider path.&#xD;
 - The embedded Qdrant service is intentionally bundled for the beginner AIO path; it is skipped only when one valid external vector backend is configured.</Overview>
-  <Changes>### 2026-05-28&#xD;
+  <Changes>### 2026-06-12&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Bump mem0 to v2.0.4</Changes>
+- Bump mem0 to v2.0.5 (#98)&#xD;
+- Use shared app test helpers</Changes>
   <Category>AI Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/mem0-aio.xml</TemplateURL>


### PR DESCRIPTION
Formal release of `mem0-aio` **v2.0.5-aio.1**. Adds CHANGELOG + Community Apps `<Changes>`; version/release tags + GitHub Release + catalog sync follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)